### PR TITLE
Added geolocation to spatial extension within annotations

### DIFF
--- a/extensions/signal.sigmf-ext.md
+++ b/extensions/signal.sigmf-ext.md
@@ -1,4 +1,4 @@
-# The `signal` SigMF Extension Namespace v1.0.0
+# The `signal` SigMF Extension Namespace v1.1.0
 
 This document defines the `signal` extension namespace for the Signal Metadata
 Format (SigMF) specification. This extension namespace defines how to describe

--- a/extensions/signal.sigmf-ext.md
+++ b/extensions/signal.sigmf-ext.md
@@ -1,4 +1,4 @@
-# The `signal` SigMF Extension Namespace v1.1.0
+# The `signal` SigMF Extension Namespace v1.0.0
 
 This document defines the `signal` extension namespace for the Signal Metadata
 Format (SigMF) specification. This extension namespace defines how to describe

--- a/extensions/spatial.sigmf-ext.md
+++ b/extensions/spatial.sigmf-ext.md
@@ -213,7 +213,7 @@ for simplicity because many applications only require azimuth, but the
 measurement error is needed. Only one of these SHOULD be used for an individual
 annotation; if both are provided the `signal_bearing` object has priority.
 
-`geolocation` uses the same GeoJSON `point` Object as in the `core` spec, but here it corresponds to an emission or signal, not the receiving platform's position.  
+`geolocation` uses the same GeoJSON `point` Object as in the `core` spec, but here it corresponds to an emission or signal, not the receiving platform's position.
 For example, this field could be used to store results of TDOA performed on an emission, or it could be used to label a known position of a transmitter.
 See `core` spec for more details on GeoJSON `point` Objects.
 

--- a/extensions/spatial.sigmf-ext.md
+++ b/extensions/spatial.sigmf-ext.md
@@ -203,14 +203,19 @@ object:
 |----|--------|----|-----|-----------|
 |`signal_azimuth`|false|double|degrees|Azimuth in degrees east of true north associated with the specific annotation.|
 |`signal_bearing`|false|[bearing](spatial.sigmf-ext.md#01-the-bearing-object)|N/A|Bearing associated with the specific annotation.|
+| `geolocation`  | false    | GeoJSON `point` Object | The location (either known or estimated) of the emission corresponding to this annotation |
 
-These fields represent the direction to a specific signal relative to the
+These first two fields represent the direction to a specific signal relative to the
 `aperture_bearing` and can be utilized when the signals contained in a Recording
 need to be defined on a per-signal basis. The `signal_azimuth` field is provided
 for simplicity because many applications only require azimuth, but the
 `signal_bearing` field is also provided for when elevation, range, and/or
 measurement error is needed. Only one of these SHOULD be used for an individual
 annotation; if both are provided the `signal_bearing` object has priority.
+
+`geolocation` uses the same GeoJSON `point` Object as in the `core` spec, but here it corresponds to an emission or signal, not the receiving platform's position.  
+For example, this field could be used to store results of TDOA performed on an emission, or it could be used to label a known position of a transmitter.
+See `core` spec for more details on GeoJSON `point` Objects.
 
 ## 4 Collection
 

--- a/extensions/spatial.sigmf-ext.md
+++ b/extensions/spatial.sigmf-ext.md
@@ -203,7 +203,7 @@ object:
 |----|--------|----|-----|-----------|
 |`signal_azimuth`|false|double|degrees|Azimuth in degrees east of true north associated with the specific annotation.|
 |`signal_bearing`|false|[bearing](spatial.sigmf-ext.md#01-the-bearing-object)|N/A|Bearing associated with the specific annotation.|
-| `geolocation`  | false    | GeoJSON `point` Object | N/A | The location (either known or estimated) of the emission corresponding to this annotation |
+| `geolocation`  | false    | GeoJSON `point` Object | N/A | The location (either known or estimated) of the transmitter corresponding to this annotation |
 
 These first two fields represent the direction to a specific signal relative to the
 `aperture_bearing` and can be utilized when the signals contained in a Recording

--- a/extensions/spatial.sigmf-ext.md
+++ b/extensions/spatial.sigmf-ext.md
@@ -203,7 +203,7 @@ object:
 |----|--------|----|-----|-----------|
 |`signal_azimuth`|false|double|degrees|Azimuth in degrees east of true north associated with the specific annotation.|
 |`signal_bearing`|false|[bearing](spatial.sigmf-ext.md#01-the-bearing-object)|N/A|Bearing associated with the specific annotation.|
-| `geolocation`  | false    | GeoJSON `point` Object | The location (either known or estimated) of the emission corresponding to this annotation |
+| `geolocation`  | false    | GeoJSON `point` Object | N/A | The location (either known or estimated) of the emission corresponding to this annotation |
 
 These first two fields represent the direction to a specific signal relative to the
 `aperture_bearing` and can be utilized when the signals contained in a Recording

--- a/extensions/spatial.sigmf-ext.md
+++ b/extensions/spatial.sigmf-ext.md
@@ -213,7 +213,7 @@ the `signal_bearing` field is also provided for when elevation, range, and/or
 measurement error is needed. Only one of these SHOULD be used for an individual
 annotation; if both are provided the `signal_bearing` object has priority.
 
-The `geolocation` field uses the same GeoJSON `point` Object as in the `core`
+The `emitter_location` field uses the same GeoJSON `point` Object as in the `core`
 spec and allows for association of a location with the annotation; not the
 recorder's position. For example, this field could be used to store
 results of TDOA performed on an emission, or it could be used to label a known

--- a/extensions/spatial.sigmf-ext.md
+++ b/extensions/spatial.sigmf-ext.md
@@ -1,4 +1,4 @@
-# The `spatial` SigMF Extension Namespace v1.0.0
+# The `spatial` SigMF Extension Namespace v1.1.0
 
 This document defines the `spatial` extension namespace for the Signal Metadata
 Format (SigMF) specification. This extension namespace contains objects to help

--- a/extensions/spatial.sigmf-ext.md
+++ b/extensions/spatial.sigmf-ext.md
@@ -203,19 +203,22 @@ object:
 |----|--------|----|-----|-----------|
 |`signal_azimuth`|false|double|degrees|Azimuth in degrees east of true north associated with the specific annotation.|
 |`signal_bearing`|false|[bearing](spatial.sigmf-ext.md#01-the-bearing-object)|N/A|Bearing associated with the specific annotation.|
-| `geolocation`  | false    | GeoJSON `point` Object | N/A | The location (either known or estimated) of the transmitter corresponding to this annotation |
+|`emitter_location`|false|GeoJSON `point` Object|N/A|The location of the emitter associated with this annotation.|
 
-These first two fields represent the direction to a specific signal relative to the
-`aperture_bearing` and can be utilized when the signals contained in a Recording
-need to be defined on a per-signal basis. The `signal_azimuth` field is provided
-for simplicity because many applications only require azimuth, but the
-`signal_bearing` field is also provided for when elevation, range, and/or
+These first two fields represent the direction to a specific signal relative to
+the `aperture_bearing` and can be utilized when the signals contained in a
+Recording need to be defined on a per-signal basis. The `signal_azimuth` field
+is provided for simplicity because many applications only require azimuth, but
+the `signal_bearing` field is also provided for when elevation, range, and/or
 measurement error is needed. Only one of these SHOULD be used for an individual
 annotation; if both are provided the `signal_bearing` object has priority.
 
-`geolocation` uses the same GeoJSON `point` Object as in the `core` spec, but here it corresponds to an emission or signal, not the receiving platform's position.
-For example, this field could be used to store results of TDOA performed on an emission, or it could be used to label a known position of a transmitter.
-See `core` spec for more details on GeoJSON `point` Objects.
+The `geolocation` field uses the same GeoJSON `point` Object as in the `core`
+spec and allows for association of a location with the annotation; not the
+recorder's position. For example, this field could be used to store
+results of TDOA performed on an emission, or it could be used to label a known
+position of a transmitter. See `core` spec for more details on GeoJSON `point`
+Objects.
 
 ## 4 Collection
 


### PR DESCRIPTION
To capture the estimated or known location of a transmitter/emission being annotated