### PR TITLE
Metadata Traceability Extension

### DIFF
--- a/extensions/traceability.sigmf-ext.md
+++ b/extensions/traceability.sigmf-ext.md
@@ -180,8 +180,8 @@ Here are some examples of using the `traceability` extension:
         "time": "2023-05-30T10:30:00Z"
       },
       "traceability:last_reviewed": {
-      "author": "ben.doe@example.com",
-      "time": "2023-05-31T12:30:00Z"
+        "author": "ben.doe@example.com",
+        "time": "2023-05-31T12:30:00Z"
       },
       "core:label": "Signal of interest",
       "core:sample_start": 100,

--- a/extensions/traceability.sigmf-ext.md
+++ b/extensions/traceability.sigmf-ext.md
@@ -15,7 +15,6 @@ The following fields are added to the `global` object:
 |`traceability:last_reviewed`|false|[DataChange](#datachange-object)|Captures the author and timestamp of the most recent review|
 |`traceability:revision`|false|integer|Specifies the revision number associated with the metadata|
 |`traceability:origin`|false|[Origin](#origin-object)|Provides information about the origin of the data|
-|`traceability:sample_length`|false|integer|Specifies the total number of samples of the Dataset|
 
 ### DataChange Object
 

--- a/extensions/traceability.sigmf-ext.md
+++ b/extensions/traceability.sigmf-ext.md
@@ -21,7 +21,7 @@ The following fields are added to the `global` object:
 |name|required|type|description|
 |----|--------|----|-----------|
 |`author`|false|string|Email address of the author who changed the metadata|
-|`time`|true|string (date-time)|Timestamp of the modification in ISO 8601 format|
+|`datetime`|true|string (date-time)|Timestamp of the modification in ISO 8601 format|
 
 ### Origin Object
 
@@ -57,11 +57,11 @@ Here are some examples of using the `traceability` extension:
   "global": {
     "traceability:last_modified": {
       "author": "john.doe@example.com",
-      "time": "2023-05-31T12:00:00Z"
+      "datetime": "2023-05-31T12:00:00Z"
     },
     "traceability:last_reviewed": {
       "author": "ben.doe@example.com",
-      "time": "2023-05-31T12:30:00Z"
+      "datetime": "2023-05-31T12:30:00Z"
     },
     "traceability:revision": 1,
     "traceability:origin": {
@@ -72,7 +72,7 @@ Here are some examples of using the `traceability` extension:
     {
       "traceability:last_modified": {
         "author": "jane.doe@example.com",
-        "time": "2023-05-30T10:30:00Z"
+        "datetime": "2023-05-30T10:30:00Z"
       },
       "core:label": "Signal of interest",
       "core:sample_start": 100,
@@ -89,11 +89,11 @@ Here are some examples of using the `traceability` extension:
   "global": {
     "traceability:last_modified": {
       "author": "john.doe@example.com",
-      "time": "2023-05-31T12:00:00Z"
+      "datetime": "2023-05-31T12:00:00Z"
     },
     "traceability:last_reviewed": {
       "author": "ben.doe@example.com",
-      "time": "2023-05-31T12:30:00Z"
+      "datetime": "2023-05-31T12:30:00Z"
     },
     "traceability:revision": 1,
     "traceability:origin": {
@@ -104,7 +104,7 @@ Here are some examples of using the `traceability` extension:
     {
       "traceability:last_modified": {
         "author": "jane.doe@example.com",
-        "time": "2023-05-30T10:30:00Z"
+        "datetime": "2023-05-30T10:30:00Z"
       },
       "core:label": "Signal of interest",
       "core:sample_start": 100,
@@ -113,11 +113,11 @@ Here are some examples of using the `traceability` extension:
     {
       "traceability:last_modified": {
         "author": "james.smith@example.com",
-        "time": "2023-05-30T15:45:00Z"
+        "datetime": "2023-05-30T15:45:00Z"
       },
       "traceability:last_reviewed": {
       "author": "ben.doe@example.com",
-      "time": "2023-05-31T12:30:00Z"
+      "datetime": "2023-05-31T12:30:00Z"
     },
     "core:label": "Noise artifact",
       "core:sample_start": 600,
@@ -134,7 +134,7 @@ Here are some examples of using the `traceability` extension:
   "global": {
     "traceability:last_modified": {
       "author": "john.doe@example.com",
-      "time": "2023-05-31T12:00:00Z"
+      "datetime": "2023-05-31T12:00:00Z"
     },
     "traceability:revision": 1,
     "traceability:origin": {
@@ -147,7 +147,7 @@ Here are some examples of using the `traceability` extension:
     {
       "traceability:last_modified": {
         "author": "jane.doe@example.com",
-        "time": "2023-05-30T10:30:00Z"
+        "datetime": "2023-05-30T10:30:00Z"
       },
       "core:label": "Signal of interest",
       "core:sample_start": 100,
@@ -164,7 +164,7 @@ Here are some examples of using the `traceability` extension:
   "global": {
     "traceability:last_modified": {
       "author": "john.doe@example.com",
-      "time": "2023-05-31T12:00:00Z"
+      "datetime": "2023-05-31T12:00:00Z"
     },
     "traceability:revision": 2,
     "traceability:origin": {
@@ -175,11 +175,11 @@ Here are some examples of using the `traceability` extension:
     {
       "traceability:last_modified": {
         "author": "jane.doe@example.com",
-        "time": "2023-05-30T10:30:00Z"
+        "datetime": "2023-05-30T10:30:00Z"
       },
       "traceability:last_reviewed": {
         "author": "ben.doe@example.com",
-        "time": "2023-05-31T12:30:00Z"
+        "datetime": "2023-05-31T12:30:00Z"
       },
       "core:label": "Signal of interest",
       "core:sample_start": 100,
@@ -188,7 +188,7 @@ Here are some examples of using the `traceability` extension:
     {
       "traceability:last_modified": {
         "author": "jane.doe@example.com",
-        "time": "2023-05-31T09:15:00Z"
+        "datetime": "2023-05-31T09:15:00Z"
       },
       "core:label": "Updated signal of interest",
       "core:sample_start": 50,

--- a/extensions/traceability.sigmf-ext.md
+++ b/extensions/traceability.sigmf-ext.md
@@ -11,16 +11,16 @@ The following fields are added to the `global` object:
 
 |name|required|type|description|
 |----|--------|----|-----------|
-|`traceability:last_modified`|false|[LastModified](#lastmodified-object)|Captures the author and timestamp of the most recent modification|
+|`traceability:last_modified`|false|[DataChange](#datachange-object)|Captures the author and timestamp of the most recent modification|
 |`traceability:revision`|false|integer|Specifies the revision number associated with the metadata|
 |`traceability:origin`|false|[Origin](#origin-object)|Provides information about the origin of the data|
 
-### LastModified Object
+### DataChange Object
 
 |name|required|type|description|
 |----|--------|----|-----------|
-|`author`|false|string|Email address of the author who last modified the metadata|
-|`time`|true|string (date-time)|Timestamp of the last modification in ISO 8601 format|
+|`author`|false|string|Email address of the author who changed the metadata|
+|`time`|true|string (date-time)|Timestamp of the modification in ISO 8601 format|
 
 ### Origin Object
 
@@ -42,7 +42,7 @@ The following fields are added to each annotation in the `annotations` array:
 
 |name|required|type|description|
 |----|--------|----|-----------|
-|`traceability:last_modified`|false|[LastModified](#lastmodified-object)|Captures the author and timestamp of the most recent modification|
+|`traceability:last_modified`|false|[DataChange](#datachange-object)|Captures the author and timestamp of the most recent modification|
 
 ## 4 Examples
 
@@ -74,9 +74,9 @@ Here are some examples of using the `traceability` extension:
     }
   ],
 }
+```
 
-
-2. Multiple annotations with traceability information:
+- Multiple annotations with traceability information:
 
 ```json
 {

--- a/extensions/traceability.sigmf-ext.md
+++ b/extensions/traceability.sigmf-ext.md
@@ -28,7 +28,6 @@ The following fields are added to the `global` object:
 
 |name|required|type|description|
 |----|--------|----|-----------|
-|`type`|true|string|Type of origin information. Ex.: `blob`,`local`,`memmory`|
 |`account`|false|string|Account name or identifier|
 |`container`|false|string|Container or repository name|
 |`file_path`|true|string|Path to the file within the container|

--- a/extensions/traceability.sigmf-ext.md
+++ b/extensions/traceability.sigmf-ext.md
@@ -1,0 +1,181 @@
+# The `traceability` SigMF Extension Namespace v1.0.0
+
+This document proposes a new extension namespace called `traceability` for the Signal Metadata
+Format (SigMF) specification. This extension provides traceability information for the metadata.
+
+## 1 Global
+
+`traceability` extends the [Global](https://github.com/gnuradio/SigMF/blob/master/sigmf-spec.md#global-object) object.
+
+The following fields are added to the `global` object:
+
+|name|required|type|description|
+|----|--------|----|-----------|
+|`traceability:last_modified`|false|[LastModified](#lastmodified-object)|Captures the author and timestamp of the most recent modification|
+|`traceability:revision`|false|integer|Specifies the revision number associated with the metadata|
+|`traceability:origin`|false|[Origin](#origin-object)|Provides information about the origin of the data|
+
+### LastModified Object
+
+|name|required|type|description|
+|----|--------|----|-----------|
+|`author`|false|string|Email address of the author who last modified the metadata|
+|`time`|true|string (date-time)|Timestamp of the last modification in ISO 8601 format|
+
+### Origin Object
+
+|name|required|type|description|
+|----|--------|----|-----------|
+|`account`|false|string|Account name or identifier|
+|`container`|false|string|Container or repository name|
+|`file_path`|true|string|Path to the file within the container|
+
+## 2 Captures
+
+`traceability` does not extend the [Captures](https://github.com/gnuradio/SigMF/blob/master/sigmf-spec.md#captures-array) object.
+
+## 3 Annotations
+
+`traceability` extends the [Annotations](https://github.com/gnuradio/SigMF/blob/master/sigmf-spec.md#annotations-object) object.
+
+The following fields are added to each annotation in the `annotations` array:
+
+|name|required|type|description|
+|----|--------|----|-----------|
+|`traceability:last_modified`|false|[LastModified](#lastmodified-object)|Captures the author and timestamp of the most recent modification|
+
+## 4 Examples
+
+Here are some examples of using the `traceability` extension:
+
+- Simple traceability information:
+
+```json
+{
+  "global": {
+    "traceability:last_modified": {
+      "author": "john.doe@example.com",
+      "time": "2023-05-31T12:00:00Z"
+    },
+    "traceability:revision": 1,
+    "traceability:origin": {
+      "file_path": "/data/signal_data.bin"
+    }
+  },
+  "annotations": [
+    {
+      "traceability:last_modified": {
+        "author": "jane.doe@example.com",
+        "time": "2023-05-30T10:30:00Z"
+      },
+      "core:label": "Signal of interest",
+      "core:sample_start": 100,
+      "core:sample_count": 500
+    }
+  ],
+}
+
+
+2. Multiple annotations with traceability information:
+
+```json
+{
+  "global": {
+    "traceability:last_modified": {
+      "author": "john.doe@example.com",
+      "time": "2023-05-31T12:00:00Z"
+    },
+    "traceability:revision": 1,
+    "traceability:origin": {
+      "file_path": "/data/signal_data.bin"
+    }
+  },
+  "annotations": [
+    {
+      "traceability:last_modified": {
+        "author": "jane.doe@example.com",
+        "time": "2023-05-30T10:30:00Z"
+      },
+      "core:label": "Signal of interest",
+      "core:sample_start": 100,
+      "core:sample_count": 500
+    },
+    {
+      "traceability:last_modified": {
+        "author": "james.smith@example.com",
+        "time": "2023-05-30T15:45:00Z"
+      },
+      "core:label": "Noise artifact",
+      "core:sample_start": 600,
+      "core:sample_count": 200
+    }
+  ]
+}
+```
+
+- Traceability information with additional origin details:
+
+```json
+{
+  "global": {
+    "traceability:last_modified": {
+      "author": "john.doe@example.com",
+      "time": "2023-05-31T12:00:00Z"
+    },
+    "traceability:revision": 1,
+    "traceability:origin": {
+      "account": "user123",
+      "container": "sigmf_data",
+      "file_path": "/data/signal_data.bin"
+    }
+  },
+  "annotations": [
+    {
+      "traceability:last_modified": {
+        "author": "jane.doe@example.com",
+        "time": "2023-05-30T10:30:00Z"
+      },
+      "core:label": "Signal of interest",
+      "core:sample_start": 100,
+      "core:sample_count": 500
+    }
+  ]
+}
+```
+
+- Multiple modifications of the metadata:
+
+```json
+{
+  "global": {
+    "traceability:last_modified": {
+      "author": "john.doe@example.com",
+      "time": "2023-05-31T12:00:00Z"
+    },
+    "traceability:revision": 2,
+    "traceability:origin": {
+      "file_path": "/data/signal_data.bin"
+    }
+  },
+  "annotations": [
+    {
+      "traceability:last_modified": {
+        "author": "jane.doe@example.com",
+        "time": "2023-05-30T10:30:00Z"
+      },
+      "core:label": "Signal of interest",
+      "core:sample_start": 100,
+      "core:sample_count": 500
+    },
+    {
+      "traceability:last_modified": {
+        "author": "jane.doe@example.com",
+        "time": "2023-05-31T09:15:00Z"
+      },
+      "core:label": "Updated signal of interest",
+      "core:sample_start": 50,
+      "core:sample_count": 700
+    }
+  ]
+}
+```

--- a/extensions/traceability.sigmf-ext.md
+++ b/extensions/traceability.sigmf-ext.md
@@ -61,6 +61,10 @@ Here are some examples of using the `traceability` extension:
       "author": "john.doe@example.com",
       "time": "2023-05-31T12:00:00Z"
     },
+    "traceability:last_reviewed": {
+      "author": "ben.doe@example.com",
+      "time": "2023-05-31T12:30:00Z"
+    },
     "traceability:revision": 1,
     "traceability:origin": {
       "file_path": "/data/signal_data.bin"
@@ -89,6 +93,10 @@ Here are some examples of using the `traceability` extension:
       "author": "john.doe@example.com",
       "time": "2023-05-31T12:00:00Z"
     },
+    "traceability:last_reviewed": {
+      "author": "ben.doe@example.com",
+      "time": "2023-05-31T12:30:00Z"
+    },
     "traceability:revision": 1,
     "traceability:origin": {
       "file_path": "/data/signal_data.bin"
@@ -109,7 +117,11 @@ Here are some examples of using the `traceability` extension:
         "author": "james.smith@example.com",
         "time": "2023-05-30T15:45:00Z"
       },
-      "core:label": "Noise artifact",
+      "traceability:last_reviewed": {
+      "author": "ben.doe@example.com",
+      "time": "2023-05-31T12:30:00Z"
+    },
+    "core:label": "Noise artifact",
       "core:sample_start": 600,
       "core:sample_count": 200
     }
@@ -166,6 +178,10 @@ Here are some examples of using the `traceability` extension:
       "traceability:last_modified": {
         "author": "jane.doe@example.com",
         "time": "2023-05-30T10:30:00Z"
+      },
+      "traceability:last_reviewed": {
+      "author": "ben.doe@example.com",
+      "time": "2023-05-31T12:30:00Z"
       },
       "core:label": "Signal of interest",
       "core:sample_start": 100,

--- a/extensions/traceability.sigmf-ext.md
+++ b/extensions/traceability.sigmf-ext.md
@@ -12,6 +12,7 @@ The following fields are added to the `global` object:
 |name|required|type|description|
 |----|--------|----|-----------|
 |`traceability:last_modified`|false|[DataChange](#datachange-object)|Captures the author and timestamp of the most recent modification|
+|`traceability:last_reviewed`|false|[DataChange](#datachange-object)|Captures the author and timestamp of the most recent review|
 |`traceability:revision`|false|integer|Specifies the revision number associated with the metadata|
 |`traceability:origin`|false|[Origin](#origin-object)|Provides information about the origin of the data|
 |`traceability:sample_length`|false|integer|Specifies the total number of samples of the Dataset|
@@ -45,6 +46,7 @@ The following fields are added to each annotation in the `annotations` array:
 |name|required|type|description|
 |----|--------|----|-----------|
 |`traceability:last_modified`|false|[DataChange](#datachange-object)|Captures the author and timestamp of the most recent modification|
+|`traceability:last_reviewed`|false|[DataChange](#datachange-object)|Captures the author and timestamp of the most recent review|
 
 ## 4 Examples
 

--- a/extensions/traceability.sigmf-ext.md
+++ b/extensions/traceability.sigmf-ext.md
@@ -14,6 +14,7 @@ The following fields are added to the `global` object:
 |`traceability:last_modified`|false|[DataChange](#datachange-object)|Captures the author and timestamp of the most recent modification|
 |`traceability:revision`|false|integer|Specifies the revision number associated with the metadata|
 |`traceability:origin`|false|[Origin](#origin-object)|Provides information about the origin of the data|
+|`traceability:sample_length`|false|integer|Specifies the total number of samples of the Dataset|
 
 ### DataChange Object
 
@@ -26,6 +27,7 @@ The following fields are added to the `global` object:
 
 |name|required|type|description|
 |----|--------|----|-----------|
+|`type`|true|string|Type of origin information. Ex.: `blob`,`local`,`memmory`|
 |`account`|false|string|Account name or identifier|
 |`container`|false|string|Container or repository name|
 |`file_path`|true|string|Path to the file within the container|


### PR DESCRIPTION
Issue: #287

View the rendered markdown here - https://github.com/Nepomuceno/SigMF/blob/traceability_extension/extensions/traceability.sigmf-ext.md

Introducing a metadata traceability extension to SigMF for maintaining an audit trail of modifications to the .sigmf-meta file. The "traceability" extension extends the existing "global" and "annotations" sections of SigMF. It allows users to include traceability information such as author details, timestamps of last modifications, revision numbers, and origin information related to where the original recording was stored.

I kindly request the SigMF community consider this proposal and evaluate the potential benefits it can bring to the ecosystem. Hopefully we can collaborate iteratively on this.

Thank you for your consideration.

closes #287 