### PR TITLE
Add core:sample_length Property to SIGMF Core Specifications

### DIFF
--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -364,6 +364,7 @@ Object:
 | `geolocation`   | false    | GeoJSON `point` Object | The location of the Recording system.|
 | `extensions`    | false    | array   | A list of JSON Objects describing extensions used by this Recording.|
 | `collection`    | false    | string  | The base filename of a `collection` with which this Recording is associated.|
+| `sample_length` | false    | uint    | The number of samples in the Dataset file.|
 
 **The `dataset` Field**
 


### PR DESCRIPTION
This PR addresses issue #289, which proposes the addition of the `core:sample_length` property to the core specifications of the Signal Metadata Format (SIGMF). The purpose of this property is to provide information about the duration or length of a recording referenced by a metadata file. The inclusion of this property simplifies the evaluation process for users interested in a particular recording and enables them to assess its duration and overall file size.

## Proposed Changes

To address this issue, the following changes have been made:

* Added the `core:sample_length` property to the core schema table specification.
* Property Details:
    * Name: `core:sample_length`
    * Required: false
    * Type: uint
    * Description: The number of samples in the Dataset file.

## Motivation

The addition of the `core:sample_length` property enhances the usability and completeness of SIGMF metadata files. Users can quickly evaluate the duration of a recording and estimate its file size based on the provided information. This addition improves interoperability and facilitates data exchange among different applications and systems.