### PR TITLE
Clarify the format of core:version

### DIFF
--- a/extensions/spatial.sigmf-ext.md
+++ b/extensions/spatial.sigmf-ext.md
@@ -434,7 +434,7 @@ element recording:
 ```JSON
 {
     "collection": {
-        "core:version": "v1.0.0",
+        "core:version": "1.0.0",
         "core:extensions" : [
             {
             "name": "spatial",

--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -351,7 +351,7 @@ Object:
 | --------------- | -------- | --------| -----------------|
 | `datatype`      | true     | string  | The SigMF Dataset format of the stored samples in the Dataset file.|
 | `sample_rate`   | false    | double  | The sample rate of the signal in samples per second.|
-| `version`       | true     | string  | The version of the SigMF specification used to create the Metadata file.|
+| `version`       | true     | string  | The version of the SigMF specification used to create the Metadata file, in the format `X.Y.Z`.|
 | `num_channels`  | false    | uint    | Total number of interleaved channels in the Dataset file; if omitted this is implied to be `1`. For multiple channels of IQ data, it is RECOMMENDED to use SigMF Collections instead of `num_channels` for widest application support.|
 | `sha512`        | false    | string  | The SHA512 hash of the Dataset file associated with the SigMF file.|
 | `offset`        | false    | uint    | The index number of the first sample in the Dataset. If not provided, this value defaults to zero. Typically used when a Recording is split over multiple files. All sample indices in SigMF are absolute, and so all other indices referenced in metadata for this recording SHOULD be greater than or equal to this value.|
@@ -742,7 +742,7 @@ Example `top-level.sigmf-collection` file:
 ```JSON
 {
     "collection": {
-        "core:version": "v1.0.0",
+        "core:version": "1.0.0",
         "core:extensions" : [
             {
                 "name": "antenna",


### PR DESCRIPTION
Some of the examples in the specification use `1.0.0`, while others use `v1.0.0`. The definition of `core:version` does not specify the exact format.

GNU Radio's SigMF Sink uses `1.0.0`, and it's the only version accepted by IQEngine's validator, so I would assume that was intended to be the correct value.

I've updated the examples and added a clarification to the definition of `core:version`.