### PR TITLE
swap PNG for SVG logo now that GitHub renders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<p align="center">
-<img src="https://github.com/gnuradio/SigMF/blob/sigmf-v1.x/logo/sigmf_logo.png" width="30%" />
-</p>
+<p align="center"><img src="https://github.com/gnuradio/SigMF/blob/sigmf-v1.x/logo/sigmf_logo.svg" alt="Rendered SigMF Logo"/></p>
 
 # Signal Metadata Format (SigMF)
 

--- a/logo/README.md
+++ b/logo/README.md
@@ -1,10 +1,10 @@
-![Rendered version of the Official SigMF Logo](sigmf_logo.png)
+<p align="center"><img src="sigmf_logo.svg" alt="Rendered SigMF Logo"/></p>
 
 # The Official SigMF Logo
 
 The provided SigMF pair [sigmf_logo.sigmf-meta](sigmf_logo.sigmf-meta) and [sigmf_logo.sigmf-data](sigmf_logo.sigmf-data) represent the stereo audio that is the official SigMF logo.
 
-The intent of these files is to both serve as a nice visual and an exemplar metadata to be used as a reference. The `png` is just a simplified view of the logo as rendered on an XY-oscilloscope per the below gist.
+The intent of these files is to both serve as a nice visual and an exemplar metadata to be used as a reference. The image above is just a simplified view of the logo as rendered on an XY-oscilloscope per the below gist.
 
 ## Additional Versions
 

--- a/logo/sigmf_logo.svg
+++ b/logo/sigmf_logo.svg
@@ -1,0 +1,3233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="260.51" height="279.63" version="1.1" viewBox="0 0 390.77 419.45" xmlns="http://www.w3.org/2000/svg">
+<defs stroke-linejoin="round">
+<filter id="d" color-interpolation-filters="sRGB">
+<feFlood flood-opacity=".859" result="flood"/>
+<feComposite in="flood" in2="SourceGraphic" operator="in" result="composite1"/>
+<feGaussianBlur in="composite1" result="blur" stdDeviation="6.587"/>
+<feOffset dx="6" dy="6" result="offset"/>
+<feComposite in="SourceGraphic" in2="offset" result="composite2"/>
+</filter>
+<filter id="c" color-interpolation-filters="sRGB">
+<feFlood flood-opacity=".859" result="flood"/>
+<feComposite in="flood" in2="SourceGraphic" operator="in" result="composite1"/>
+<feGaussianBlur in="composite1" result="blur" stdDeviation="6.587"/>
+<feOffset dx="6" dy="6" result="offset"/>
+<feComposite in="SourceGraphic" in2="offset" result="composite2"/>
+</filter>
+<style type="text/css">*{stroke-linecap:butt;stroke-linejoin:round}</style>
+</defs>
+<defs>
+<clipPath id="a" stroke-linejoin="round">
+<path d="M0 0h502.2v498.96H0z" stroke-linejoin="round"/>
+</clipPath>
+</defs>
+<g transform="matrix(.81833 0 0 .81497 19.176 -.263)" font-family="'Eurostile LT Std'" stroke-width="5">
+<g transform="translate(-705.99 -231.73)" fill="#2cdaff" filter="url(#d)" font-size="264.57" font-weight="700" text-anchor="end" style="shape-inside:url(#a);white-space:pre" aria-label="MF">
+<path d="m766.11 542.73h1.588l50.797 152.13h45.77l50.267-152.13h1.852l-5.291 152.13h52.913v-198.43h-85.984l-35.981 124.61h-1.852l-37.833-124.61h-83.868v198.42h52.914zm281.24-2.911h87.836v-43.389h-140.75v198.43h52.914v-72.756h80.957v-43.39h-80.957z" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal"/>
+</g>
+<g transform="translate(-479.38 -97.244)" fill="#fff" filter="url(#c)" font-size="245.67" font-stretch="expanded" font-weight="400" text-anchor="middle" style="shape-inside:url(#c);white-space:pre" aria-label="sig">
+<path d="M493.071 251.987c0 37.587 29.235 37.587 60.435 37.587h38.815c25.796 0 58.224-1.228 58.224-36.359v-.491c0-33.903-21.619-37.096-53.31-37.096h-55.767c-22.11 0-25.55-5.896-25.55-16.215v-4.667c0-14.249 6.633-17.197 36.85-17.197h36.851c23.093 0 35.868.491 35.868 19.653v1.229h19.653v-6.633c0-17.688-6.633-31.446-54.293-31.446H558.42c-52.082 0-63.628 11.3-63.628 31.691v7.37c0 23.83 11.055 33.411 40.78 33.411h65.103c25.304 0 28.744 6.634 28.744 18.671v.983c0 18.67-10.073 19.9-41.764 19.9H542.45c-21.62 0-29.726-6.388-29.726-21.865v-6.142H493.07zm195.553 35.622h21.127V162.317h-21.127zm0-154.772h21.127v-23.093h-21.127zm197.272 98.268c0 21.619-11.055 33.656-41.273 33.656h-40.78c-25.796 0-36.114-8.844-35.868-37.587v-23.093c.245-20.636 15.722-26.532 37.341-26.532h42.992c29.726 0 38.079 14.986 37.588 38.324zm21.127-68.788H887.37v22.356h-.492c-6.633-20.39-22.601-24.32-38.57-24.32h-44.957c-23.584 0-56.504 5.158-56.504 50.607v20.882c0 32.182 17.442 50.116 52.573 50.116h43.484c29.48 0 38.078-7.615 42.5-19.408h.492v18.671c0 33.903-16.706 34.394-58.47 34.394H806.79c-19.653 0-36.359-4.668-36.359-20.882v-3.44h-19.653v4.177c0 15.969 10.318 37.342 49.133 37.342h47.66c26.287 0 59.452-7.616 59.452-45.449z" style="font-variant-caps:normal;font-variant-east-asian:normal;font-variant-ligatures:normal;font-variant-numeric:normal"/>
+</g>
+</g>
+<g transform="translate(-55.269 -35.96)" stroke-linejoin="round">
+<path d="m263.41 159.88 1.19-6.85" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.534"/>
+<path d="m264.6 153.03-0.143 4.238" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.015"/>
+<path d="m264.46 157.27-1.064 11.79" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.779"/>
+<path d="m263.39 169.06-1.525 13.825" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.498"/>
+<path d="m261.87 182.88-2.013 10.623" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.926"/>
+<path d="m259.85 193.51-2.439 4.289" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.889"/>
+<path d="m257.42 197.8-2.98-2.272" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.111"/>
+<path d="m254.44 195.52-3.45-6.67" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.443"/>
+<path d="m250.98 188.86-3.643-7.879" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.253"/>
+<path d="m247.34 180.98-2.963-6.538" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.498"/>
+<path d="m244.38 174.44-1.474-4.226" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.972"/>
+<path d="m242.9 170.21 0.357-2.637" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.317"/>
+<path d="m243.26 167.58 1.62-2.743" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.216"/>
+<path d="m244.88 164.83 1.942-4.502" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.894"/>
+<path d="m246.82 160.33 1.154-6.932" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.522"/>
+<path d="m247.98 153.4-0.266-8.73" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.243"/>
+<path d="m247.71 144.67-1.59-8.901" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.195"/>
+<path d="m246.12 135.77-1.874-7.362" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.427"/>
+<path d="m244.25 128.41-0.956-4.856" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.885"/>
+<path d="m243.29 123.55 0.645-2.687" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.297"/>
+<path d="m243.94 120.86 1.867-2.083" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.292"/>
+<path d="m245.8 118.78 2.033-3.713" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.018"/>
+<path d="m247.84 115.07 0.967-7.223" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.478"/>
+<path d="m248.8 107.84-0.63-11.36" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.844"/>
+<path d="m248.17 96.484-1.626-14.395" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.424"/>
+<path d="m246.55 82.089-0.914-14.975" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.358"/>
+<path d="m245.63 67.114 1.603-12.533" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.668"/>
+<path d="m247.24 54.581 4.905-7.66" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.188"/>
+<path d="m252.14 46.92 7.147-1.844" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.47"/>
+<path d="m259.29 45.076 6.787 2.904" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.469"/>
+<path d="m266.07 47.98 3.255 5.142" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.685"/>
+<path d="m269.33 53.122-2.397 4.515" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.857"/>
+<path d="m266.93 57.637-7.807 2.036" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.357"/>
+<path d="m259.12 59.673-9.946-0.484" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.063"/>
+<path d="m249.18 59.189-6.728-0.907" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.569"/>
+<path d="m242.45 58.282 2.138 2.206" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.239"/>
+<path d="m244.59 60.488 14.698 8.994" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.102"/>
+<path d="m259.29 69.482 27.686 17.965" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".803"/>
+<path d="m286.97 87.447 37.215 26.633" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".297"/>
+<path d="m324.19 114.08 40.356 32.273" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".17"/>
+<path d="m364.55 146.35 35.948 33.035" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".224"/>
+<path d="m400.49 179.39 25.44 28.226" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".558"/>
+<path d="m425.93 207.61 11.724 19.261" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.552"/>
+<path d="m437.66 226.88-1.559 8.693" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.228"/>
+<path d="m436.1 235.57-11.446-0.464" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.843"/>
+<path d="m424.65 235.1-15.942-6.113" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.122"/>
+<path d="m408.71 228.99-15.207-7.253" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.147"/>
+<path d="m393.5 221.74-10.912-4.617" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.786"/>
+<path d="m382.59 217.12-5.733-0.086" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.751"/>
+<path d="m376.86 217.03-1.686 3.817" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.029"/>
+<path d="m375.17 220.85-0.201 5.49" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.787"/>
+<path d="m374.97 226.34-1.375 4.48" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.933"/>
+<path d="m373.6 230.82-4.392 1.738" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.931"/>
+<path d="m369.21 232.56-7.387-1.443" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.446"/>
+<path d="m361.82 231.12-9.056-3.406" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.105"/>
+<path d="m352.76 227.71-8.827-3.415" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.137"/>
+<path d="m343.94 224.3-7.291-1.64" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.455"/>
+<path d="m336.65 222.66-5.156 0.448" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.85"/>
+<path d="m331.49 223.1-3.583 1.772" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.064"/>
+<path d="m327.91 224.88-3.23 1.563" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.141"/>
+<path d="m324.68 226.44-4.212 0.017" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.026"/>
+<path d="m320.46 226.46-5.557-2.493" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.688"/>
+<path d="m314.91 223.96-6.372-4.734" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.376"/>
+<path d="m308.54 219.23-5.97-5.937" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.297"/>
+<path d="m302.56 213.29-4.4-5.75" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.489"/>
+<path d="m298.16 207.54-1.903-4.928" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.826"/>
+<path d="m296.26 202.62 0.705-3.759" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.093"/>
+<path d="m296.97 198.86 2.709-2.633" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.104"/>
+<path d="m299.68 196.22 3.626-1.445" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.082"/>
+<path d="m303.3 194.78 3.741-0.53" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.106"/>
+<path d="M307.043 194.25l3.44.655" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.158"/>
+<path d="m310.48 194.9 3.214 2.122" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.091"/>
+<path d="m313.7 197.03 3.28 3.73" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.884"/>
+<path d="m316.98 200.76 3.844 4.49" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.716"/>
+<path d="m320.82 205.25 4.666 4.348" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.636"/>
+<path d="m325.49 209.6 5.45 3.294" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.639"/>
+<path d="m330.94 212.89 5.902 1.878" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.67"/>
+<path d="m336.84 214.77 6.025 0.144" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.7"/>
+<path d="m342.86 214.91 5.888-1.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.708"/>
+<path d="m348.75 213.86 5.665-1.412" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.733"/>
+<path d="m354.42 212.45 5.406-0.86" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.797"/>
+<path d="m359.82 211.59 5.51-0.195" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.79"/>
+<path d="m365.33 211.4 5.765 0.329" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.744"/>
+<path d="m371.1 211.72 6.046 0.42" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.694"/>
+<path d="m377.14 212.14 6.03 0.172" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.699"/>
+<path d="m383.17 212.32 5.986-0.615" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.702"/>
+<path d="m389.16 211.7 5.53-1.698" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.742"/>
+<path d="m394.69 210 4.683-2.892" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.79"/>
+<path d="m399.37 207.11 3.492-3.84" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.844"/>
+<path d="m402.86 203.27 2.542-4.794" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.801"/>
+<path d="m405.4 198.48 1.77-5.527" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.733"/>
+<path d="m407.17 192.95 1.17-5.858" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.703"/>
+<path d="m408.34 187.1 0.468-5.379" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.804"/>
+<path d="m408.81 181.72-0.151-4.361" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.992"/>
+<path d="m408.66 177.36-1.026-2.784" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.258"/>
+<path d="m407.64 174.57-2.161-0.89" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.383"/>
+<path d="m405.48 173.68-3.559 1.172" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.112"/>
+<path d="m401.92 174.85-4.605 2.61" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.828"/>
+<path d="m397.31 177.46-5.282 3.226" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.67"/>
+<path d="m392.03 180.69-5.563 2.962" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.651"/>
+<path d="m386.46 183.65-5.755 2.245" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.673"/>
+<path d="m380.71 185.9-5.679 1.054" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.744"/>
+<path d="m375.03 186.95-5.656-0.105" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.765"/>
+<path d="m369.38 186.84-5.754-0.897" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.735"/>
+<path d="m363.62 185.95-6.109-0.93" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.673"/>
+<path d="m357.51 185.02-6.197-0.667" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.664"/>
+<path d="m351.32 184.35-6.05-0.215" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.695"/>
+<path d="m345.26 184.14-5.7 0.147" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.757"/>
+<path d="m339.56 184.28-5.534 0.428" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.784"/>
+<path d="m334.03 184.71-5.308 0.1" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.826"/>
+<path d="m328.72 184.81-5.25-0.661" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.83"/>
+<path d="m323.47 184.15-5.308-1.685" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.78"/>
+<path d="m318.17 182.46-5.56-2.52" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.685"/>
+<path d="m312.61 179.94-5.335-3.402" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.646"/>
+<path d="m307.27 176.54-4.655-4.098" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.667"/>
+<path d="m302.62 172.44-3.576-4.6" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.731"/>
+<path d="m299.04 167.84-2.593-4.74" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.805"/>
+<path d="m296.45 163.1-1.486-5.019" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.834"/>
+<path d="m294.96 158.08-0.67-5.38" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.8"/>
+<path d="m294.29 152.7-0.239-5.796" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.733"/>
+<path d="m294.05 146.91-0.387-5.962" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.702"/>
+<path d="m293.66 140.95-0.353-6.115" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.676"/>
+<path d="m293.31 134.83-0.15-6.08" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.684"/>
+<path d="m293.16 128.75 0.313-5.877" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.718"/>
+<path d="m293.47 122.87 0.7-5.42" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.792"/>
+<path d="m294.17 117.45 1.487-5.133" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.814"/>
+<path d="m295.66 112.32 2.274-4.973" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.793"/>
+<path d="m297.93 107.35 2.955-4.893" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.75"/>
+<path d="m300.89 102.45 3.223-4.601" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.767"/>
+<path d="m304.11 97.853 3.785-4.196" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.762"/>
+<path d="m307.9 93.657 4.42-3.489" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.767"/>
+<path d="m312.32 90.168 5.116-2.525" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.755"/>
+<path d="m317.43 87.643 5.48-1.35" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.767"/>
+<path d="m322.91 86.294 6.037-0.49" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.695"/>
+<path d="m328.95 85.803 6.365-5e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.642"/>
+<path d="M335.315 85.798l6.388.084" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.638"/>
+<path d="m341.7 85.882 5.868 0.114" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.727"/>
+<path d="M347.57 85.996l5.558-.141" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.782"/>
+<path d="m353.13 85.855 5.338-0.336" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.819"/>
+<path d="m358.47 85.519 5.329-0.364" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.821"/>
+<path d="m363.8 85.155 5.309 0.018" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.826"/>
+<path d="m369.1 85.173 5.744 0.317" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.748"/>
+<path d="M374.848 85.49l6.185.651" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.667"/>
+<path d="m381.03 86.141 6.375 1.042" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.625"/>
+<path d="m387.41 87.183 5.914 1.753" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.675"/>
+<path d="m393.32 88.936 5.188 2.313" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.76"/>
+<path d="m398.51 91.249 4.101 2.702" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.896"/>
+<path d="m402.61 93.951 2.902 2.667" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.074"/>
+<path d="m405.51 96.618 1.743 2.203" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.289"/>
+<path d="M407.256 98.821l1.254.817" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.551"/>
+<path d="m408.51 99.638 1.355-1.081" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.503"/>
+<path d="m409.86 98.557 1.908-2.915" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.159"/>
+<path d="m411.77 95.642 2.485-3.745" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.97"/>
+<path d="m414.26 91.897 3.008-3.435" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.957"/>
+<path d="m417.27 88.462 3.108-1.68" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.152"/>
+<path d="m420.37 86.781 2.724 1.149" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.262"/>
+<path d="m423.1 87.93 1.898 4.482" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.901"/>
+<path d="m425 92.412 1.103 6.98" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.515"/>
+<path d="m426.1 99.392 0.467 8.146" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.335"/>
+<path d="m426.57 107.54 0.076 7.834" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.388"/>
+<path d="m426.64 115.37-0.225 6.651" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.585"/>
+<path d="m426.42 122.02-0.35 5" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.874"/>
+<path d="m426.07 127.02-0.455 3.9" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.074"/>
+<path d="m425.61 130.92-0.51 3.873" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.078"/>
+<path d="m425.1 134.8-0.52 5.078" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.857"/>
+<path d="m424.58 139.87-0.172 6.565" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.6"/>
+<path d="m424.41 146.44 0.371 7.747" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.4"/>
+<path d="m424.78 154.18 0.84 7.86" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.376"/>
+<path d="m425.62 162.04 0.727 6.61" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.586"/>
+<path d="m426.35 168.65 0.048 3.546" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.146"/>
+<path d="m426.4 172.2-1.282-0.65" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.563"/>
+<path d="m425.12 171.55-2.923-5.237" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.7"/>
+<path d="m422.19 166.31-4.504-9.199" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.012"/>
+<path d="m417.69 157.11-5.15-12.273" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.578"/>
+<path d="m412.54 144.84-4.823-13.656" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.425"/>
+<path d="m407.72 131.18-3.821-13.114" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.531"/>
+<path d="m403.9 118.07-2.993-10.625" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.894"/>
+<path d="m400.9 107.44-2.55-7.19" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.422"/>
+<path d="m398.35 100.26-3.026-3.352" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.967"/>
+<path d="m395.33 96.903-4.278-0.017" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.013"/>
+<path d="m391.05 96.886-6.013 2.26" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.631"/>
+<path d="m385.04 99.146-6.978 2.59" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.459"/>
+<path d="m378.06 101.74-6.98 1.473" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.511"/>
+<path d="m371.08 103.21-6.128-0.354" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.681"/>
+<path d="m364.95 102.86-5.187-1.78" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.794"/>
+<path d="m359.76 101.08-4.451-2.423" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.868"/>
+<path d="m355.31 98.652-4.615-1.74" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.893"/>
+<path d="m350.7 96.913-5.585-0.085" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.777"/>
+<path d="m345.11 96.828-6.654 1.617" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.559"/>
+<path d="m338.46 98.445-7.111 2.682" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.433"/>
+<path d="m331.35 101.13-6.665 2.942" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.485"/>
+<path d="m324.68 104.07-5.341 2.615" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.713"/>
+<path d="m319.34 106.68-3.45 2.134" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.053"/>
+<path d="m315.89 108.82-1.706 2.187" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.296"/>
+<path d="m314.18 111-0.787 3.248" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.185"/>
+<path d="m313.4 114.25-0.778 5.099" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.847"/>
+<path d="m312.62 119.35-1.152 6.948" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.519"/>
+<path d="m311.47 126.3-1.298 7.979" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.347"/>
+<path d="m310.17 134.28-0.933 7.897" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.368"/>
+<path d="m309.24 142.18 0.07 6.76" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.567"/>
+<path d="m309.31 148.94 1.616 4.978" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.834"/>
+<path d="m310.92 153.92 3.2 3.29" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.953"/>
+<path d="m314.12 157.2 4.158 2.444" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.912"/>
+<path d="m318.28 159.65 4.297 2.608" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.875"/>
+<path d="m322.58 162.26 3.98 3.322" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.846"/>
+<path d="m326.56 165.58 3.707 3.831" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.819"/>
+<path d="m330.26 169.41 3.807 3.583" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.838"/>
+<path d="m334.07 172.99 4.57 2.276" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.861"/>
+<path d="M338.64 175.269l6.052.1" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.696"/>
+<path d="m344.69 175.37 7.713-2.18" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.366"/>
+<path d="m352.4 173.19 8.606-3.476" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.165"/>
+<path d="m361.01 169.71 8.119-3.076" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.259"/>
+<path d="m369.13 166.64 6.342-1.02" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.631"/>
+<path d="m375.47 165.62 3.923 1.734" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.01"/>
+<path d="m379.4 167.35 1.875 3.774" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.021"/>
+<path d="m381.27 171.13 1.458 3.588" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.085"/>
+<path d="m382.73 174.71 3.465 0.491" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.159"/>
+<path d="m386.19 175.2 7.21-4.957" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.246"/>
+<path d="m393.4 170.25 10.498-10.279" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.403"/>
+<path d="m403.9 159.97 10.452-12.277" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.227"/>
+<path d="m414.35 147.69 4.686-8.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.154"/>
+<path d="m419.04 139.64-7.8 3.231" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.297"/>
+<path d="m411.24 142.87-25.63 20.319" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".819"/>
+<path d="m385.61 163.19-44.89 39.23" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".069"/>
+<path d="m340.72 202.42-60.201 54.68" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".001"/>
+<path d="m280.52 257.1-66.962 61.56" clip-path="url(#a)" fill="none" stroke-linejoin="round"/>
+<path d="m213.56 318.66-62.952 57.631" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="0"/>
+<path d="m150.6 376.29-49.161 43.807" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".028"/>
+<path d="m101.44 420.1-29.47 24.149" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".555"/>
+<path d="m71.973 444.25-9.51 3.975" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.009"/>
+<path d="m62.462 448.22 5.501-11.288" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.681"/>
+<path d="m67.963 436.94 12.64-18.634" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.556"/>
+<path d="m80.604 418.3 12.092-18.02" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.632"/>
+<path d="m92.696 400.28 6.388-12.3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.507"/>
+<path d="m99.084 387.98-0.752-5.079" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.852"/>
+<path d="m98.332 382.9-5.98 0.245" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.707"/>
+<path d="m92.353 383.15-7.445 1.888" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.421"/>
+<path d="m84.908 385.04-5.392-0.203" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.811"/>
+<path d="m79.516 384.83-1.5-4.204" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.974"/>
+<path d="m78.015 380.63 2.165-7.987" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.317"/>
+<path d="m80.18 372.64 4.15-9.964" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.93"/>
+<path d="m84.33 362.68 3.903-9.714" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.978"/>
+<path d="m88.233 352.96 1.933-7.672" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.375"/>
+<path d="m90.166 345.29-0.587-5.067" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.858"/>
+<path d="m89.58 340.22-2.396-3.2" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.062"/>
+<path d="m87.184 337.02-2.805-2.844" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.063"/>
+<path d="m84.38 334.18-1.893-3.875" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.003"/>
+<path d="m82.487 330.3-0.246-5.638" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.761"/>
+<path d="m82.241 324.67 1.35-7.298" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.456"/>
+<path d="m83.592 317.37 2.202-8.051" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.305"/>
+<path d="m85.794 309.32 1.907-7.553" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.396"/>
+<path d="m87.701 301.77 0.684-6.129" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.669"/>
+<path d="m88.385 295.64-0.814-4.63" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.93"/>
+<path d="m87.571 291.01-1.771-3.81" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.023"/>
+<path d="m85.8 287.2-1.865-4.014" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.982"/>
+<path d="m83.935 283.18-1.058-5.091" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.84"/>
+<path d="m82.877 278.09 0.288-6.46" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.617"/>
+<path d="m83.165 271.63 1.735-7.26" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.449"/>
+<path d="m84.9 264.37 2.63-6.782" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.481"/>
+<path d="m87.53 257.59 2.858-4.97" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.746"/>
+<path d="m90.388 252.62 2.72-2.405" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.132"/>
+<path d="m93.109 250.21 2.941-0.086" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.266"/>
+<path d="m96.05 250.13 3.69 1.308" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.08"/>
+<path d="m99.74 251.44 4.978 1.451" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.848"/>
+<path d="m104.72 252.89 6.45 0.59" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.622"/>
+<path d="m111.17 253.48 7.603-0.614" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.43"/>
+<path d="m118.77 252.86 7.834-1.354" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.377"/>
+<path d="m126.6 251.51 7.044-1.204" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.509"/>
+<path d="m133.65 250.3 5.748-0.358" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="m139.4 249.94 4.249 1.04" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.995"/>
+<path d="m143.64 250.98 3.344 2.189" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.064"/>
+<path d="m146.99 253.17 3.204 2.812" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.014"/>
+<path d="m150.19 255.99 3.635 2.966" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.935"/>
+<path d="m153.83 258.95 3.732 3.352" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.876"/>
+<path d="m157.56 262.3 3.334 4.043" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.835"/>
+<path d="m160.89 266.35 2.396 5.063" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.769"/>
+<path d="m163.29 271.41 1.317 6.07" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.661"/>
+<path d="m164.61 277.48 0.333 6.891" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.543"/>
+<path d="m164.94 284.37 0.101 6.986" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.529"/>
+<path d="m165.04 291.36 0.695 6.328" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.634"/>
+<path d="m165.74 297.68 1.814 5.203" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.785"/>
+<path d="m167.55 302.89 2.631 4.391" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.856"/>
+<path d="m170.18 307.28 2.935 4.156" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.862"/>
+<path d="m173.12 311.44 2.597 4.62" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.823"/>
+<path d="m175.71 316.06 1.869 5.48" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.735"/>
+<path d="m177.58 321.54 0.964 6.446" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.608"/>
+<path d="m178.55 327.98 0.546 6.835" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.551"/>
+<path d="m179.09 334.82 0.801 6.288" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.639"/>
+<path d="m179.89 341.1 1.592 4.695" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.884"/>
+<path d="m181.48 345.8 2.275 2.557" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.171"/>
+<path d="M183.76 348.358l2.692.176" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.313"/>
+<path d="m186.45 348.53 2.648-2.051" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.186"/>
+<path d="m189.1 346.48 2.231-3.96" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.96"/>
+<path d="m191.33 342.52 1.475-5.223" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.8"/>
+<path d="m192.81 337.3 0.943-5.96" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.692"/>
+<path d="m193.75 331.34 0.86-6.27" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.641"/>
+<path d="m194.61 325.07 1.242-6.396" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.609"/>
+<path d="m195.85 318.67 1.64-6.185" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.629"/>
+<path d="m197.49 312.49 2.023-5.803" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.673"/>
+<path d="m199.51 306.69 2.202-5.366" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.734"/>
+<path d="m201.72 301.32 2.136-5.15" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.773"/>
+<path d="m203.85 296.17 1.671-5.027" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.823"/>
+<path d="m205.52 291.14 1.224-5.079" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.836"/>
+<path d="m206.74 286.06 1-5.277" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.809"/>
+<path d="m207.74 280.79 1.116-5.688" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.734"/>
+<path d="m208.86 275.1 1.369-5.86" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.695"/>
+<path d="m210.23 269.24 1.893-5.666" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.703"/>
+<path d="m212.12 263.57 2.594-5.004" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.763"/>
+<path d="m214.72 258.57 3.366-4.103" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.823"/>
+<path d="m218.08 254.47 3.97-2.775" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.908"/>
+<path d="m222.05 251.69 4.539-1.314" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.931"/>
+<path d="m226.59 250.38 5.076-0.018" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.868"/>
+<path d="M231.666 250.36l5.59.63" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="M237.257 250.99l5.923.85" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.707"/>
+<path d="M243.18 251.84l6.189.617" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.667"/>
+<path d="m249.37 252.46 6.354 0.142" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.643"/>
+<path d="m255.72 252.6 6.399-0.513" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.632"/>
+<path d="m262.12 252.09 6.088-0.682" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.683"/>
+<path d="m268.21 251.4 5.524-0.282" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.787"/>
+<path d="m273.73 251.12 4.736 0.673" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.921"/>
+<path d="m278.47 251.8 3.838 1.765" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.022"/>
+<path d="m282.31 253.56 2.756 3.113" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.033"/>
+<path d="m285.06 256.67 1.731 4.326" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.939"/>
+<path d="m286.8 261 0.862 5.245" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.819"/>
+<path d="m287.66 266.24 0.241 5.639" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.76"/>
+<path d="m287.9 271.88-0.274 5.956" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.704"/>
+<path d="m287.62 277.84-0.571 6.142" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.669"/>
+<path d="m287.05 283.98-0.648 6.242" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.65"/>
+<path d="m286.4 290.22-0.48 6.062" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.684"/>
+<path d="m285.92 296.28-0.259 5.96" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.704"/>
+<path d="m285.66 302.24 0.05 5.761" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.74"/>
+<path d="m285.72 308 0.343 5.525" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.78"/>
+<path d="m286.06 313.53 0.541 5.212" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.833"/>
+<path d="m286.6 318.74 0.441 5.272" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.823"/>
+<path d="m287.04 324.01 0.162 5.545" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.778"/>
+<path d="m287.2 329.56-0.182 5.92" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.711"/>
+<path d="m287.02 335.48-0.4 6.116" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.675"/>
+<path d="m286.62 341.6-0.485 6.228" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.655"/>
+<path d="m286.14 347.82-0.32 6.058" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.686"/>
+<path d="m285.82 353.88 9e-3 5.69" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.752"/>
+<path d="m285.83 359.57 0.363 5.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.83"/>
+<path d="m286.19 364.81 0.47 5.119" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.851"/>
+<path d="M286.66 369.93l.348 5.339" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.813"/>
+<path d="m287.01 375.27 0.071 5.813" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.731"/>
+<path d="m287.08 381.08-0.176 6.192" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.664"/>
+<path d="m286.9 387.27-0.385 6.387" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.629"/>
+<path d="m286.52 393.66-0.492 6.11" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.675"/>
+<path d="m286.03 399.77-0.643 5.309" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.813"/>
+<path d="m285.38 405.08-1.032 4.006" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.035"/>
+<path d="m284.35 409.08-1.963 2.68" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.19"/>
+<path d="m282.39 411.76-3.369 1.554" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.119"/>
+<path d="m279.02 413.32-4.981 0.774" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.874"/>
+<path d="m274.04 414.09-6.314 0.158" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.65"/>
+<path d="m267.73 414.25-7.005-0.221" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.532"/>
+<path d="m260.72 414.03-6.742-0.62" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.572"/>
+<path d="m253.98 413.41-5.556-1.212" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.759"/>
+<path d="m248.42 412.2-3.736-2.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.998"/>
+<path d="m244.69 409.96-1.854-3.347" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.094"/>
+<path d="m242.83 406.61-0.378-4.415" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.98"/>
+<path d="m242.46 402.2 0.44-5.268" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.824"/>
+<path d="m242.9 396.93 0.67-6" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.692"/>
+<path d="m243.56 390.93 0.506-6.258" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.65"/>
+<path d="M244.07 384.67l.228-6.174" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.667"/>
+<path d="m244.3 378.5 0.06-5.892" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.717"/>
+<path d="m244.36 372.6 0.136-5.816" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.73"/>
+<path d="m244.49 366.79 0.319-5.685" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.752"/>
+<path d="m244.81 361.1 0.429-5.617" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.763"/>
+<path d="m245.24 355.49 0.369-5.578" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="m245.61 349.91 0.246-5.757" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.74"/>
+<path d="m245.86 344.15 0.058-5.714" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.748"/>
+<path d="m245.91 338.44-0.087-5.602" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.768"/>
+<path d="m245.83 332.83-0.1-5.507" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.785"/>
+<path d="m245.73 327.33 0.127-5.747" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.742"/>
+<path d="m245.85 321.58 0.388-5.912" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.711"/>
+<path d="m246.24 315.67 0.521-6.015" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.691"/>
+<path d="m246.76 309.65 0.41-5.806" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.729"/>
+<path d="m247.17 303.85 0.138-5.212" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.837"/>
+<path d="m247.31 298.64-0.38-3.648" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.123"/>
+<path d="m246.93 294.99-1.031-1.358" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.508"/>
+<path d="m245.9 293.63-1.655 1.32" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.426"/>
+<path d="m244.24 294.95-1.978 3.682" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.028"/>
+<path d="m242.26 298.63-2.077 5.633" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.698"/>
+<path d="m240.19 304.26-1.997 6.664" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.534"/>
+<path d="m238.19 310.93-1.844 6.775" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.523"/>
+<path d="m236.35 317.7-1.609 6.098" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.645"/>
+<path d="m234.74 323.8-1.557 5.49" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.75"/>
+<path d="m233.18 329.29-1.715 5.1" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.808"/>
+<path d="m231.46 334.39-1.995 5.07" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.796"/>
+<path d="m229.47 339.46-2.097 5.155" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.775"/>
+<path d="m227.37 344.62-2.07 5.525" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.716"/>
+<path d="m225.3 350.14-1.894 5.693" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.699"/>
+<path d="m223.41 355.83-1.663 5.576" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.73"/>
+<path d="m221.75 361.41-1.365 5.157" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.816"/>
+<path d="m220.38 366.57-1.355 5.072" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.831"/>
+<path d="m219.03 371.64-1.637 5.217" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.792"/>
+<path d="m217.39 376.86-2.076 5.565" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.709"/>
+<path d="m215.31 382.42-2.27 5.761" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.665"/>
+<path d="m213.04 388.18-2.298 5.985" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.628"/>
+<path d="m210.74 394.17-2.117 5.752" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.676"/>
+<path d="m208.63 399.92-1.943 5.007" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.81"/>
+<path d="m206.68 404.93-1.933 3.714" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.026"/>
+<path d="m204.75 408.64-2.622 2.629" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.116"/>
+<path d="m202.13 411.27-3.939 1.72" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.009"/>
+<path d="m198.19 412.99-5.528 1.045" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="m192.66 414.04-6.637 0.28" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.594"/>
+<path d="m186.03 414.32-6.985-0.3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.535"/>
+<path d="m179.04 414.01-6.295-1.087" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.637"/>
+<path d="m172.75 412.93-4.795-2.126" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.837"/>
+<path d="m167.95 410.8-2.89-3.517" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.96"/>
+<path d="m165.06 407.28-1.535-4.54" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.914"/>
+<path d="m163.53 402.74-1.092-5.196" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.82"/>
+<path d="m162.44 397.55-1.514-5.443" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.76"/>
+<path d="m160.92 392.1-2.217-5.616" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.692"/>
+<path d="m158.7 386.49-2.715-5.49" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.678"/>
+<path d="m155.99 381-2.572-5.409" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.701"/>
+<path d="m153.42 375.59-1.837-5.454" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.742"/>
+<path d="m151.58 370.14-1.12-5.69" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.734"/>
+<path d="m150.46 364.45-0.69-5.752" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.734"/>
+<path d="m149.77 358.69-0.903-5.651" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="m148.87 353.04-1.66-5.393" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.761"/>
+<path d="m147.21 347.65-2.717-5.189" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.724"/>
+<path d="m144.49 342.46-3.228-4.968" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.713"/>
+<path d="m141.26 337.49-2.93-4.954" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.742"/>
+<path d="m138.33 332.54-1.949-5.193" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.779"/>
+<path d="m136.38 327.35-1.002-5.734" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.73"/>
+<path d="m135.38 321.61-0.39-6.1" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.678"/>
+<path d="m134.99 315.51-0.52-6.175" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.664"/>
+<path d="m134.47 309.34-1.323-5.739" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.718"/>
+<path d="m133.15 303.6-2.565-4.833" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.793"/>
+<path d="m130.58 298.76-3.277-3.122" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.965"/>
+<path d="m127.3 295.64-3.01-0.964" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.223"/>
+<path d="m124.29 294.68-1.721 1.321" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.416"/>
+<path d="m122.57 296-0.055 3.194" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.213"/>
+<path d="m122.52 299.19 1.515 4.829" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.865"/>
+<path d="m124.03 304.02 2.283 5.915" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.64"/>
+<path d="m126.32 309.94 1.92 6.5" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.564"/>
+<path d="m128.24 316.44 0.44 6.533" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.603"/>
+<path d="m128.68 322.97-1.256 6.622" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.57"/>
+<path d="m127.42 329.59-2.297 6.574" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.533"/>
+<path d="m125.12 336.17-2.03 6.315" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.589"/>
+<path d="m123.09 342.48-0.523 5.578" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.768"/>
+<path d="m122.57 348.06 1.716 4.954" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.833"/>
+<path d="m124.29 353.02 3.547 4.443" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.756"/>
+<path d="m127.83 357.46 3.793 4.41" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.733"/>
+<path d="m131.63 361.87 1.778 4.9" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.838"/>
+<path d="m133.4 366.77-1.824 6.375" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.589"/>
+<path d="m131.58 373.14-5.209 7.927" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.128"/>
+<path d="m126.37 381.07-5.936 8.507" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.994"/>
+<path d="m120.44 389.58-1.968 6.8" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.514"/>
+<path d="m118.47 396.38 7.547 2.87" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.356"/>
+<path d="m126.01 399.25 21.476-3.217" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.639"/>
+<path d="m147.49 396.03 36.66-10.164" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".561"/>
+<path d="m184.15 385.87 48.805-16.36" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".175"/>
+<path d="m232.96 369.51 54.212-19.403" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".09"/>
+<path d="m287.17 350.1 51.123-18.603" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".129"/>
+<path d="m338.29 331.5 40.335-14.258" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".386"/>
+<path d="m378.62 317.24 24.98-8.097" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.25"/>
+<path d="m403.6 309.14 9.46-1.578" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.118"/>
+<path d="m413.06 307.57-2.029 3.215" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.099"/>
+<path d="m411.04 310.78-7.179 5.293" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.219"/>
+<path d="m403.86 316.08-6.135 4.544" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.426"/>
+<path d="m397.72 320.62-1.137 2.579" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.287"/>
+<path d="m396.58 323.2 4.81 0.64" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.908"/>
+<path d="m401.4 323.84 8.895-0.129" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.226"/>
+<path d="M410.29 323.71l9.585.469" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.118"/>
+<path d="m419.88 324.18 6.906 2.494" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.476"/>
+<path d="m426.78 326.67 2.408 4.88" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.798"/>
+<path d="m429.19 331.55-2.047 6.626" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.538"/>
+<path d="m427.14 338.18-5.01 6.892" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.28"/>
+<path d="m422.13 345.07-6.008 5.917" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.295"/>
+<path d="m416.12 350.99-5.266 3.98" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.599"/>
+<path d="m410.86 354.97-3.784 1.755" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.032"/>
+<path d="m407.07 356.72-2.706-0.238" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.309"/>
+<path d="m404.37 356.48-2.874-1.3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.224"/>
+<path d="m401.49 355.18-4.178-1.457" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.986"/>
+<path d="m397.32 353.72-6.056-0.946" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.682"/>
+<path d="m391.26 352.78-7.679-0.284" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.42"/>
+<path d="m383.58 352.5-8.394 0.437" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.304"/>
+<path d="m375.19 352.93-7.699 0.897" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.409"/>
+<path d="m367.49 353.83-5.812 1.13" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.718"/>
+<path d="m361.68 354.96-3.448 1.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.127"/>
+<path d="m358.23 356.2-1.54 1.757" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.382"/>
+<path d="m356.69 357.96-0.484 2.688" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.303"/>
+<path d="m356.2 360.64-0.344 3.98" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.061"/>
+<path d="m355.86 364.62-0.76 5.295" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.813"/>
+<path d="m355.1 369.92-1.22 6.531" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.587"/>
+<path d="m353.88 376.45-1.086 7.18" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.483"/>
+<path d="m352.79 383.63-0.286 7.077" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.512"/>
+<path d="m352.51 390.71 0.728 6.241" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.649"/>
+<path d="m353.24 396.95 1.164 5.214" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.814"/>
+<path d="m354.4 402.16 0.645 4.097" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.033"/>
+<path d="m355.04 406.26-0.939 3.105" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.204"/>
+<path d="m354.11 409.36-3.27 2.25" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.069"/>
+<path d="m350.84 411.61-5.563 1.713" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.735"/>
+<path d="m345.27 413.33-7.003 1.148" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.517"/>
+<path d="m338.27 414.48-7.2 0.44" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.498"/>
+<path d="m331.07 414.92-6.499-0.442" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.616"/>
+<path d="m324.57 414.47-4.97-1.268" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.858"/>
+<path d="m319.6 413.2-3.458-2.053" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.06"/>
+<path d="m316.14 411.15-2.37-2.782" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.127"/>
+<path d="m313.77 408.37-1.98-3.54" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.051"/>
+<path d="m311.8 404.83-1.49-4.27" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.964"/>
+<path d="m310.31 400.56-0.897-5.082" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.847"/>
+<path d="m309.41 395.48-0.123-5.88" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.719"/>
+<path d="m309.29 389.6 0.397-6.523" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.605"/>
+<path d="m309.68 383.07 1.005-6.688" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.567"/>
+<path d="m310.69 376.39 1.161-6.44" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.604"/>
+<path d="m311.85 369.94 0.807-5.914" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.703"/>
+<path d="m312.66 364.03-0.172-5.413" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.801"/>
+<path d="m312.48 358.62-0.742-5.03" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.861"/>
+<path d="m311.74 353.59-0.926-5.054" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.851"/>
+<path d="m310.82 348.53-0.644-5.438" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.79"/>
+<path d="m310.17 343.1-0.355-6.042" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.689"/>
+<path d="m309.82 337.05 0.329-6.311" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.642"/>
+<path d="m310.15 330.74 0.807-6.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.647"/>
+<path d="m310.95 324.5 0.894-5.864" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.71"/>
+<path d="m311.85 318.64 0.322-5.496" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.785"/>
+<path d="m312.17 313.14-0.127-5.135" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.851"/>
+<path d="m312.04 308.01-0.486-5.142" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.846"/>
+<path d="m311.56 302.87-0.595-5.509" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.779"/>
+<path d="m310.96 297.36-0.658-6.128" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.67"/>
+<path d="m310.3 291.23-0.246-6.417" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.625"/>
+<path d="m310.06 284.82 0.25-6.341" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.638"/>
+<path d="m310.31 278.47 0.654-5.896" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.71"/>
+<path d="m310.96 272.58 0.679-5.346" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.806"/>
+<path d="m311.64 267.23 0.803-4.624" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.932"/>
+<path d="m312.44 262.61 1.007-4.043" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.029"/>
+<path d="m313.45 258.56 1.519-3.555" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.086"/>
+<path d="m314.97 255.01 2.3-3.088" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.09"/>
+<path d="m317.27 251.92 3.778-2.073" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.006"/>
+<path d="m321.05 249.85 5.496-0.745" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.784"/>
+<path d="m326.54 249.1 6.992 0.605" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.531"/>
+<path d="m333.54 249.71 7.731 1.45" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.39"/>
+<path d="m341.27 251.16 7.577 1.692" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.407"/>
+<path d="m348.84 252.85 6.476 1.019" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.609"/>
+<path d="M355.32 253.87l4.97-.218" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.886"/>
+<path d="m360.29 253.65 4.009-1.302" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.024"/>
+<path d="m364.3 252.35 3.962-1.539" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.018"/>
+<path d="m368.26 250.81 4.869-0.936" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.889"/>
+<path d="M373.13 249.875l6.266.18" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.658"/>
+<path d="m379.4 250.05 7.538 1.182" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.429"/>
+<path d="m386.93 251.24 7.861 1.612" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.365"/>
+<path d="m394.8 252.85 6.982 1.025" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.524"/>
+<path d="m401.78 253.87 5.297-0.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.827"/>
+<path d="m407.07 253.63 3.751-1.357" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.066"/>
+<path d="m410.82 252.28 2.986-1.38" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.198"/>
+<path d="m413.81 250.9 3.21-0.106" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.214"/>
+<path d="m417.02 250.79 3.998 2.192" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.96"/>
+<path d="m421.02 252.98 4.578 4.753" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.598"/>
+<path d="m425.6 257.74 4.034 6.669" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.396"/>
+<path d="m429.63 264.4 2.005 7.128" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.459"/>
+<path d="m431.64 271.53-1.044 6.079" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.669"/>
+<path d="m430.59 277.61-3.987 4.17" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.742"/>
+<path d="m426.6 281.78-5.737 2.317" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.671"/>
+<path d="m420.87 284.1-5.792 1.147" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.721"/>
+<path d="m415.07 285.24-4.476 0.882" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.961"/>
+<path d="m410.6 286.13-2.797 1.287" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.239"/>
+<path d="m407.8 287.41-2.026 1.638" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.33"/>
+<path d="m405.78 289.05-3.04 1.265" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.198"/>
+<path d="m402.73 290.32-5.695 1e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.758"/>
+<path d="m397.04 290.32-8.798-1.586" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.219"/>
+<path d="m388.24 288.73-10.732-2.75" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.897"/>
+<path d="m377.51 285.98-10.213-2.646" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.974"/>
+<path d="m367.3 283.33-6.91-0.863" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.54"/>
+<path d="m360.38 282.47-1.795 2.34" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.262"/>
+<path d="m358.59 284.81 2.773 5.55" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.664"/>
+<path d="m361.36 290.36 4 7.029" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.348"/>
+<path d="m365.36 297.39-0.24 5.194" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.84"/>
+<path d="m365.12 302.58-10.331-0.528" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.005"/>
+<path d="m354.79 302.06-24.785-9.677" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.223"/>
+<path d="m330.01 292.38-40.17-20.156" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".321"/>
+<path d="m289.84 272.22-52.086-29.002" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".069"/>
+<path d="m237.75 243.22-56.497-33.2" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".03"/>
+<path d="m181.26 210.02-51.581-31.255" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".063"/>
+<path d="m129.67 178.77-38.217-23.322" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".325"/>
+<path d="m91.457 155.45-19.81-11.561" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.524"/>
+<path d="m71.648 143.88-1.086 0.767" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.585"/>
+<path d="m70.562 144.65 13.143 9.982" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.185"/>
+<path d="m83.705 154.63 19.872 13.887" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.409"/>
+<path d="m103.58 168.52 18.919 12.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.56"/>
+<path d="m122.5 180.76 12.827 6.922" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.421"/>
+<path d="m135.32 187.68 5.248 0.458" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.834"/>
+<path d="m140.57 188.14-0.418-4.413" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.98"/>
+<path d="m140.15 183.73-2.19-6.143" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.608"/>
+<path d="m137.96 177.58-9e-3 -4.568" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.954"/>
+<path d="m137.95 173.02 4.356-1.35" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.961"/>
+<path d="m142.31 171.67 8.373 1.73" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.281"/>
+<path d="m150.68 173.4 10.258 3.252" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.943"/>
+<path d="m160.94 176.65 9.649 3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.04"/>
+<path d="m170.59 179.65 7.373 1.165" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.456"/>
+<path d="m177.96 180.81 4.658-1.169" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.917"/>
+<path d="m182.62 179.64 2.743-3.053" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.043"/>
+<path d="m185.36 176.59 2.198-3.839" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.983"/>
+<path d="m187.56 172.75 2.751-3.948" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.912"/>
+<path d="m190.31 168.8 3.254-3.83" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.874"/>
+<path d="m193.57 164.97 2.814-3.884" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.915"/>
+<path d="m196.38 161.09 1.142-3.981" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.034"/>
+<path d="m197.52 157.11-1.346-4.145" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.994"/>
+<path d="m196.18 152.96-4.106-4.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="m192.07 148.95-6.341-3.346" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.504"/>
+<path d="m185.73 145.61-7.491-1.994" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.409"/>
+<path d="m178.24 143.61-7.346-0.536" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.473"/>
+<path d="m170.89 143.08-6.46 0.601" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.621"/>
+<path d="m164.43 143.68-5.418 1.106" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.787"/>
+<path d="m159.01 144.78-4.713 1.133" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.909"/>
+<path d="m154.3 145.92-4.512 0.626" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.962"/>
+<path d="m149.79 146.54-4.94-0.068" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.893"/>
+<path d="m144.85 146.48-5.732-0.638" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.745"/>
+<path d="m139.12 145.84-6.505-0.733" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.611"/>
+<path d="m132.61 145.1-6.782-0.539" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.567"/>
+<path d="m125.83 144.56-6.573-0.249" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.605"/>
+<path d="m119.26 144.32-5.968-0.106" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.71"/>
+<path d="m113.29 144.21-5.121-0.123" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.86"/>
+<path d="m108.17 144.09-4.461-0.702" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.969"/>
+<path d="m103.71 143.38-4.121-1.754" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.976"/>
+<path d="m99.587 141.63-4.056-3.104" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.86"/>
+<path d="m95.53 138.53-3.807-4.216" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.757"/>
+<path d="m91.723 134.31-3.514-5.306" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.637"/>
+<path d="m88.21 129-2.625-5.966" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.61"/>
+<path d="m85.585 123.04-1.148-6.136" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.656"/>
+<path d="m84.437 116.9 0.787-5.688" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.743"/>
+<path d="m85.224 111.21 2.283-5.251" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="m87.507 105.96 3.233-4.814" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.735"/>
+<path d="m90.74 101.15 3.616-4.397" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.754"/>
+<path d="m94.356 96.752 3.906-3.68" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.813"/>
+<path d="m98.262 93.072 4.017-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.877"/>
+<path d="m102.28 90.072 4.445-2.165" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.891"/>
+<path d="m106.72 87.907 5.217-1.26" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.816"/>
+<path d="m111.94 86.648 6.305-0.245" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.651"/>
+<path d="M118.246 86.403l6.852.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.558"/>
+<path d="m125.1 86.643 6.781 0.269" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.57"/>
+<path d="m131.88 86.912 6.141-0.054" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.68"/>
+<path d="M138.02 86.858l5.495-.273" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.792"/>
+<path d="m143.52 86.585 4.863-0.516" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.901"/>
+<path d="m148.38 86.069 4.72-0.466" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.928"/>
+<path d="m153.1 85.603 5.107-0.142" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.862"/>
+<path d="m158.2 85.461 5.96 0.472" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.708"/>
+<path d="M164.166 85.933l6.513.736" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.609"/>
+<path d="M170.679 86.669l6.585.713" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.597"/>
+<path d="M177.264 87.382l6.134.51" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.678"/>
+<path d="m183.4 87.892 5.559 0.616" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.776"/>
+<path d="M188.957 88.508l4.848.899" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.894"/>
+<path d="m193.8 89.407 4.354 1.72" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.939"/>
+<path d="m198.16 91.126 4.038 2.985" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.876"/>
+<path d="m202.2 94.11 3.776 4.536" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.718"/>
+<path d="m205.97 98.646 2.891 5.421" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.674"/>
+<path d="m208.86 104.07 1.379 5.434" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.768"/>
+<path d="m210.24 109.5-0.611 4.436" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.971"/>
+<path d="m209.63 113.94-2.519 2.825" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.103"/>
+<path d="m207.11 116.76-4.15 0.604" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.029"/>
+<path d="m202.96 117.36-4.955-1.503" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.849"/>
+<path d="m198.01 115.86-4.901-3.055" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.742"/>
+<path d="m193.11 112.81-4.203-3.64" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.779"/>
+<path d="m188.9 109.17-3.715-3.69" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.836"/>
+<path d="m185.19 105.48-3.655-3.174" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.908"/>
+<path d="m181.53 102.3-4.163-2.317" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.923"/>
+<path d="m177.37 99.986-4.947-1.168" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.866"/>
+<path d="m172.42 98.818-5.995-0.278" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.704"/>
+<path d="m166.43 98.54-6.666 0.413" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.588"/>
+<path d="m159.76 98.953-6.738 0.803" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.57"/>
+<path d="m153.02 99.756-6.151 0.981" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.665"/>
+<path d="m146.87 100.74-5.629 0.588" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.764"/>
+<path d="m141.24 101.32-5.24 5e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.839"/>
+<path d="m136 101.33-5.17-0.483" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.847"/>
+<path d="m130.84 100.85-5.215-0.42" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.84"/>
+<path d="m125.62 100.43-5.595 2e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.776"/>
+<path d="m120.02 100.43-5.697 1.055" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.74"/>
+<path d="m114.33 101.48-5.199 2.539" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.741"/>
+<path d="m109.13 104.02-3.783 4.206" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.761"/>
+<path d="m105.35 108.23-2.017 5.185" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.776"/>
+<path d="m103.33 113.42 0.058 5.44" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.797"/>
+<path d="m103.39 118.86 2.102 4.937" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.811"/>
+<path d="m105.49 123.79 4.013 4.022" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.757"/>
+<path d="m109.5 127.81 5.129 2.616" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.746"/>
+<path d="m114.63 130.43 5.65 1.336" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.738"/>
+<path d="M120.28 131.766l5.74.426" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="M126.02 132.192l5.872.087" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.727"/>
+<path d="m131.89 132.28 5.782-0.229" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.742"/>
+<path d="m137.67 132.05 5.768-0.385" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.743"/>
+<path d="m143.44 131.66 5.826-0.448" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.732"/>
+<path d="m149.27 131.22 6.114-0.259" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.684"/>
+<path d="m155.38 130.96 6.037-0.223" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.698"/>
+<path d="m161.42 130.74 5.734-0.053" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.751"/>
+<path d="m167.15 130.68 5.325 0.228" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.823"/>
+<path d="M172.478 130.91l5.18.748" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.839"/>
+<path d="m177.66 131.66 5.199 0.848" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.834"/>
+<path d="m182.86 132.51 5.498 0.815" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.782"/>
+<path d="M188.355 133.32l5.868.824" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.718"/>
+<path d="m194.22 134.14 5.943 1.408" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.686"/>
+<path d="m200.17 135.55 5.413 2.14" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.735"/>
+<path d="m205.58 137.69 4.27 3.282" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.81"/>
+<path d="m209.85 140.98 2.748 4.613" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.811"/>
+<path d="m212.6 145.59 1.263 6.006" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.674"/>
+<path d="m213.86 151.59 0.103 6.564" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.6"/>
+<path d="m213.96 158.16-0.515 6.39" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.627"/>
+<path d="m213.45 164.55-0.774 5.63" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.754"/>
+<path d="m212.68 170.18-1.06 4.863" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.88"/>
+<path d="m211.62 175.04-1.865 3.948" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.993"/>
+<path d="m209.75 178.99-3.192 3.369" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.944"/>
+<path d="m206.56 182.36-4.786 3.091" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.756"/>
+<path d="m201.77 185.45-6.117 3.046" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.56"/>
+<path d="m195.66 188.5-6.868 2.466" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.483"/>
+<path d="m188.79 190.96-6.696 1.492" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.557"/>
+<path d="m182.09 192.45-5.82 0.305" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.735"/>
+<path d="m176.27 192.76-4.75-0.553" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.921"/>
+<path d="m171.52 192.21-4.3-1.116" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.983"/>
+<path d="m167.22 191.09-4.63-0.95" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.931"/>
+<path d="m162.59 190.14-5.62-0.195" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.771"/>
+<path d="m156.97 189.95-6.703 0.86" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.575"/>
+<path d="m150.27 190.81-7.5 1.297" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.432"/>
+<path d="m142.77 192.1-7.331 1.04" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.466"/>
+<path d="m135.44 193.14-6.182 0.151" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.673"/>
+<path d="m129.26 193.3-4.487-0.81" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.961"/>
+<path d="m124.77 192.48-3.373-1.714" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.104"/>
+<path d="m121.4 190.77-3.37-1.934" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.085"/>
+<path d="m118.03 188.84-4.72-1.416" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.894"/>
+<path d="m113.31 187.42-6.863-0.386" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.555"/>
+<path d="m106.45 187.03-8.806-0.031" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.24"/>
+<path d="m97.64 187-8.724-0.899" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.246"/>
+<path d="m88.916 186.1-5.192-3.41" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.666"/>
+<path d="m83.724 182.69 2.361-7.193" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.432"/>
+<path d="m86.085 175.5 12.893-11.956" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.059"/>
+<path d="m98.978 163.54 24.397-16.253" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.028"/>
+<path d="m123.38 147.29 33.925-18.755" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".53"/>
+<path d="m157.3 128.54 38.715-18.244" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".385"/>
+<path d="m196.02 110.29 36.982-15.02" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".485"/>
+<path d="m233 95.272 29.096-9.442" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".948"/>
+<path d="m262.09 85.83 17.224-2.76" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.081"/>
+<path d="m279.32 83.07 4.752 3.799" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.687"/>
+<path d="m284.07 86.869-5.056 8.252" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.099"/>
+<path d="m279.01 95.121-9.908 10.15" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.468"/>
+<path d="m269.1 105.27-9.492 9.661" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.551"/>
+<path d="m259.61 114.93-5.332 7.983" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.111"/>
+<path d="m254.28 122.91-0.04 5.704" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.75"/>
+<path d="m254.24 128.62 3.954 4.07" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.758"/>
+<path d="m258.19 132.69 5.233 3.58" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.644"/>
+<path d="m263.43 136.27 3.862 4.39" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.728"/>
+<path d="m267.29 140.66 0.977 5.397" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.789"/>
+<path d="m268.27 146.06-1.715 6.174" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.628"/>
+<path d="m266.55 152.23-2.97 6.391" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.52"/>
+<path d="m263.58 158.62-2.582 6.292" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.561"/>
+<path d="m261 164.91-0.997 5.858" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.708"/>
+<path d="m260 170.77 0.705 5.493" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.779"/>
+<path d="m260.71 176.26 1.468 5.187" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.806"/>
+<path d="m262.18 181.45 0.569 4.68" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.928"/>
+<path d="m262.74 186.13-1.475 3.454" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.107"/>
+<path d="m261.27 189.58-3.742 1.452" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.062"/>
+<path d="m257.53 191.04-5.195-1.051" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.828"/>
+<path d="m252.33 189.98-5.277-3.38" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.656"/>
+<path d="m247.06 186.6-3.834-5.087" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.636"/>
+<path d="m243.22 181.52-1.377-5.764" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.711"/>
+<path d="m241.84 175.75 1.088-5.613" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.748"/>
+<path d="m242.93 170.14 2.472-5.172" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.746"/>
+<path d="m245.4 164.97 2.304-5.199" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.754"/>
+<path d="m247.71 159.77 0.94-5.834" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.714"/>
+<path d="m248.65 153.94-0.805-6.759" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.559"/>
+<path d="m247.84 147.18-2.013-7.242" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.44"/>
+<path d="m245.83 139.93-2.086-6.888" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.494"/>
+<path d="m243.75 133.05-0.856-5.56" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.764"/>
+<path d="m242.89 127.48 0.968-3.923" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.053"/>
+<path d="m243.86 123.56 2.303-3.006" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.102"/>
+<path d="m246.16 120.56 2.179-3.92" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.971"/>
+<path d="m248.34 116.64 0.775-6.735" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.564"/>
+<path d="m249.11 109.9-1.076-10.624" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.946"/>
+<path d="m248.04 99.278-2.141-13.911" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.476"/>
+<path d="m245.9 85.367-1.468-15.261" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.318"/>
+<path d="m244.43 70.106 1.176-13.558" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.537"/>
+<path d="m245.61 56.548 4.762-9.073" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.012"/>
+<path d="m250.37 47.475 7.37-3.085" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.37"/>
+<path d="m257.74 44.39 7.405 2.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.422"/>
+<path d="m265.14 46.4 4.14 4.848" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.636"/>
+<path d="m269.28 51.248-1.464 4.877" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.86"/>
+<path d="m267.82 56.125-7.064 3.004" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.42"/>
+<path d="m260.75 59.129-9.561 0.653" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.12"/>
+<path d="m251.19 59.782-6.77 0.123" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.572"/>
+<path d="m244.42 59.905 1.727 2.88" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.183"/>
+<path d="m246.15 62.784 14.077 9.197" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.149"/>
+<path d="m260.23 71.981 27.07 17.49" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".847"/>
+<path d="m287.3 89.471 36.788 25.604" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".323"/>
+<path d="m324.08 115.08 40.23 30.972" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".186"/>
+<path d="m364.32 146.05 36.155 31.797" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".239"/>
+<path d="m400.47 177.84 25.922 27.338" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".572"/>
+<path d="m426.39 205.18 12.364 18.88" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.551"/>
+<path d="m438.76 224.06-0.904 8.826" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.221"/>
+<path d="m437.85 232.89-10.903 0.062" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.923"/>
+<path d="m426.95 232.95-15.6-5.392" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.188"/>
+<path d="m411.35 227.56-15.09-6.536" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.194"/>
+<path d="m396.26 221.02-10.97-4.057" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.808"/>
+<path d="m385.29 216.97-5.862 0.233" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.728"/>
+<path d="m379.43 217.2-1.777 3.894" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.009"/>
+<path d="m377.65 221.09-0.18 5.39" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.805"/>
+<path d="m377.47 226.48-1.233 4.3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.973"/>
+<path d="m376.24 230.78-4.182 1.573" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.978"/>
+<path d="m372.06 232.36-7.204-1.507" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.474"/>
+<path d="m364.85 230.85-8.98-3.338" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.119"/>
+<path d="m355.87 227.51-8.89-3.235" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.138"/>
+<path d="m346.98 224.28-7.45-1.406" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.437"/>
+<path d="M339.53 222.87l-5.316.677" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.817"/>
+<path d="m334.21 223.55-3.647 1.961" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.038"/>
+<path d="m330.57 225.51-3.156 1.735" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.139"/>
+<path d="m327.41 227.24-4.05 0.245" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.054"/>
+<path d="m323.36 227.49-5.434-2.129" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.732"/>
+<path d="m317.93 225.36-6.448-4.202" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.416"/>
+<path d="m311.48 221.16-6.37-5.3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.319"/>
+<path d="m305.11 215.86-5.158-5.171" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.479"/>
+<path d="m299.95 210.69-2.929-4.622" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.793"/>
+<path d="m297.02 206.06-0.408-3.924" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.071"/>
+<path d="m296.61 202.14 1.715-3.353" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.105"/>
+<path d="m298.33 198.79 2.91-2.64" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.076"/>
+<path d="m301.24 196.15 3.359-1.963" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.084"/>
+<path d="m304.6 194.18 3.34-0.691" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.176"/>
+<path d="m307.94 193.49 3.258 1.16" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.166"/>
+<path d="m311.19 194.65 3.297 3.334" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.935"/>
+<path d="m314.49 197.99 3.717 4.668" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.706"/>
+<path d="m318.21 202.66 4.354 4.949" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.599"/>
+<path d="m322.56 207.6 5.005 4.08" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.623"/>
+<path d="m327.56 211.68 5.429 2.606" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.7"/>
+<path d="m332.99 214.29 5.647 0.656" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.76"/>
+<path d="m338.64 214.95 5.685-0.804" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.75"/>
+<path d="m344.32 214.14 5.64-1.386" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.738"/>
+<path d="m349.96 212.76 5.499-0.958" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.778"/>
+<path d="m355.46 211.8 5.617-0.302" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="m361.08 211.5 5.807 0.3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.737"/>
+<path d="m366.89 211.8 5.998 0.52" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.701"/>
+<path d="m372.89 212.32 5.945 0.419" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.712"/>
+<path d="m378.83 212.74 5.977-0.213" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.708"/>
+<path d="m384.81 212.52 5.705-1.136" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.736"/>
+<path d="m390.51 211.39 5.101-2.19" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.782"/>
+<path d="m395.61 209.2 4.128-3.056" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.855"/>
+<path d="m399.74 206.14 3.289-4.033" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.841"/>
+<path d="m403.03 202.11 2.49-4.945" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.781"/>
+<path d="m405.52 197.16 1.765-5.63" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.716"/>
+<path d="m407.28 191.54 0.933-5.65" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.746"/>
+<path d="m408.22 185.89 0.266-5.181" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.842"/>
+<path d="m408.48 180.7-0.531-4.07" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.041"/>
+<path d="m407.95 176.64-1.496-2.42" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.282"/>
+<path d="m406.46 174.22-2.717-0.28" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.306"/>
+<path d="m403.74 173.94-3.7 1.565" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.061"/>
+<path d="m400.04 175.5-4.49 2.82" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.826"/>
+<path d="m395.55 178.32-5.04 3.243" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.704"/>
+<path d="m390.51 181.56-5.559 3.048" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.644"/>
+<path d="m384.95 184.61-5.74 2.064" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.686"/>
+<path d="m379.21 186.68-5.82 0.755" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.727"/>
+<path d="m373.39 187.43-5.859-0.452" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.726"/>
+<path d="m367.53 186.98-6.054-0.97" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.682"/>
+<path d="m361.48 186.01-6.009-1.057" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.687"/>
+<path d="m355.47 184.95-5.834-0.684" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.726"/>
+<path d="m349.63 184.27-5.582-0.122" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.778"/>
+<path d="m344.05 184.15-5.562 0.53" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.777"/>
+<path d="m338.49 184.68-5.456 0.577" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.795"/>
+<path d="m333.03 185.26-5.418 0.047" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.807"/>
+<path d="m327.62 185.3-5.425-0.944" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.791"/>
+<path d="m322.19 184.36-5.623-1.897" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.715"/>
+<path d="m316.57 182.46-5.451-2.927" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.671"/>
+<path d="m311.12 179.54-4.97-3.697" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.669"/>
+<path d="m306.15 175.84-4.18-4.167" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.718"/>
+<path d="m301.97 171.67-3.44-4.224" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.798"/>
+<path d="m298.53 167.45-2.41-4.47" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.863"/>
+<path d="m296.12 162.98-1.437-4.924" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.853"/>
+<path d="m294.68 158.05-0.666-5.557" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.769"/>
+<path d="m294.01 152.5-0.449-5.971" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.7"/>
+<path d="m293.56 146.52-0.206-6.302" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.645"/>
+<path d="m293.36 140.22-0.053-6.297" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.646"/>
+<path d="m293.3 133.93 0.13-5.982" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.701"/>
+<path d="m293.44 127.94 0.15-5.362" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.81"/>
+<path d="m293.59 122.58 0.655-4.99" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.87"/>
+<path d="m294.24 117.59 1.375-4.914" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.858"/>
+<path d="m295.62 112.68 2.21-5.075" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.781"/>
+<path d="m297.83 107.6 2.736-5.08" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.74"/>
+<path d="m300.56 102.52 3.495-4.907" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.696"/>
+<path d="m304.06 97.615 4.16-4.282" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.706"/>
+<path d="m308.22 93.333 4.727-3.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.749"/>
+<path d="m312.95 90.092 4.92-1.906" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.832"/>
+<path d="m317.86 88.186 5.42-0.889" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.794"/>
+<path d="m323.28 87.297 5.9-0.32" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.721"/>
+<path d="m329.18 86.978 6.259-0.216" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.659"/>
+<path d="m335.44 86.762 6.104-0.195" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.686"/>
+<path d="m341.55 86.567 6.012-0.38" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.701"/>
+<path d="m347.56 86.188 5.74-0.41" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="M353.3 85.778l5.43-.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.804"/>
+<path d="M358.73 85.538l5.005.252" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.879"/>
+<path d="M363.735 85.79l5.172.457" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.847"/>
+<path d="M368.906 86.247l5.639.473" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.764"/>
+<path d="M374.545 86.72l6.18.425" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.671"/>
+<path d="M380.725 87.145l6.256.779" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.652"/>
+<path d="m386.98 87.924 6.058 1.285" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.671"/>
+<path d="m393.04 89.21 5.268 2.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.765"/>
+<path d="m398.31 91.26 4.03 2.774" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.899"/>
+<path d="m402.34 94.034 2.526 3.224" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.044"/>
+<path d="m404.86 97.258 1.556 2.575" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.25"/>
+<path d="M406.417 99.833l1.22.927" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.544"/>
+<path d="m407.64 100.76 1.516-1.31" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.449"/>
+<path d="m409.15 99.45 2.05-3.135" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.109"/>
+<path d="m411.2 96.315 2.724-4.145" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.885"/>
+<path d="m413.93 92.17 3.07-3.642" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.921"/>
+<path d="m417 88.528 2.944-1.612" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.185"/>
+<path d="m419.94 86.916 2.332 1.617" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.285"/>
+<path d="m422.27 88.533 1.695 4.715" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.875"/>
+<path d="m423.97 93.248 1.146 6.96" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.517"/>
+<path d="m425.11 100.21 0.759 7.835" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.382"/>
+<path d="m425.87 108.04 0.361 7.566" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.43"/>
+<path d="m426.23 115.61 0.034 6.261" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.652"/>
+<path d="m426.27 121.87-0.36 4.865" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.898"/>
+<path d="m425.91 126.74-0.728 4.06" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.037"/>
+<path d="m425.18 130.8-0.977 4.362" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.973"/>
+<path d="m424.2 135.16-0.714 5.245" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.823"/>
+<path d="m423.49 140.4-0.047 6.46" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.618"/>
+<path d="m423.44 146.86 0.755 7.376" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.457"/>
+<path d="m424.2 154.24 1.122 7.57" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.418"/>
+<path d="m425.32 161.81 0.923 6.224" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.647"/>
+<path d="m426.24 168.03-0.068 3.509" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.153"/>
+<path d="m426.17 171.54-1.629-0.31" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.519"/>
+<path d="m424.54 171.23-3.42-4.503" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.761"/>
+<path d="m421.12 166.73-4.536-8.803" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.064"/>
+<path d="m416.59 157.92-4.771-12.122" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.616"/>
+<path d="m411.82 145.8-4.203-13.743" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.439"/>
+<path d="m407.61 132.06-3.488-13.112" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.543"/>
+<path d="m404.12 118.95-2.786-10.81" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.876"/>
+<path d="m401.34 108.14-2.714-7.176" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.415"/>
+<path d="m398.62 100.96-3.378-3.175" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.945"/>
+<path d="m395.25 97.785-4.747 0.338" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.925"/>
+<path d="m390.5 98.123-5.81 2.096" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.673"/>
+<path d="m384.69 100.22-6.353 2.17" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.582"/>
+<path d="m378.34 102.39-6.241 0.983" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.65"/>
+<path d="m372.1 103.37-5.932-0.443" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.714"/>
+<path d="m366.16 102.93-5.317-1.72" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.776"/>
+<path d="m360.85 101.21-5.027-2.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.807"/>
+<path d="m355.82 99.2-5.219-1.262" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.815"/>
+<path d="m350.6 97.938-5.722 0.03" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.753"/>
+<path d="m344.88 97.969-6.162 1.256" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.655"/>
+<path d="m338.72 99.225-6.398 2.146" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.575"/>
+<path d="m332.32 101.37-6.2 2.539" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.584"/>
+<path d="m326.12 103.91-5.317 2.398" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.733"/>
+<path d="m320.8 106.31-3.967 2.194" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.965"/>
+<path d="m316.84 108.5-2.613 2.47" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.139"/>
+<path d="m314.22 110.97-1.585 3.426" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.103"/>
+<path d="m312.64 114.4-0.939 4.829" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.891"/>
+<path d="m311.7 119.22-0.65 6.246" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.649"/>
+<path d="m311.05 125.47-0.692 7.355" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.462"/>
+<path d="m310.36 132.82-0.705 7.73" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.4"/>
+<path d="m309.65 140.56-0.181 7.072" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.514"/>
+<path d="m309.47 147.63 0.993 5.575" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.758"/>
+<path d="m310.46 153.2 2.422 3.919" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.949"/>
+<path d="m312.89 157.12 3.661 2.744" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.957"/>
+<path d="m316.55 159.86 4.415 2.376" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.878"/>
+<path d="m320.96 162.24 4.523 2.754" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.827"/>
+<path d="m325.49 164.99 4.04 3.496" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.818"/>
+<path d="m329.52 168.49 3.568 3.813" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.839"/>
+<path d="m333.09 172.3 3.925 2.97" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.894"/>
+<path d="m337.02 175.27 5.359 0.862" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.805"/>
+<path d="m342.38 176.14 7.265-1.73" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.455"/>
+<path d="m349.64 174.4 8.683-3.613" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.146"/>
+<path d="m358.32 170.79 8.768-3.727" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.127"/>
+<path d="m367.09 167.06 7.128-1.792" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.475"/>
+<path d="m374.22 165.27 4.167 1.454" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.988"/>
+<path d="m378.39 166.72 1.394 4.22" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.978"/>
+<path d="m379.78 170.94 0.696 4.562" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.946"/>
+<path d="m380.48 175.51 2.941 1.334" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.21"/>
+<path d="m383.42 176.84 7.233-4.524" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.281"/>
+<path d="m390.65 172.32 11.145-10.385" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.336"/>
+<path d="m401.8 161.93 11.544-12.616" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.113"/>
+<path d="m413.34 149.31 5.626-8.46" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.026"/>
+<path d="m418.97 140.85-7.53 3.296" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.332"/>
+<path d="m411.44 144.15-25.972 20.804" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".787"/>
+<path d="m385.46 164.95-45.188 39.764" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".064"/>
+<path d="m340.28 204.72-59.952 54.476" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".001"/>
+<path d="m280.32 259.19-66.028 60.627" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="0"/>
+<path d="m214.3 319.82-61.598 56.247" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="0"/>
+<path d="m152.7 376.07-47.876 42.66" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".037"/>
+<path d="m104.82 418.73-28.921 23.562" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".589"/>
+<path d="m75.898 442.29-10.024 4.427" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.913"/>
+<path d="m65.874 446.72 4.233-10.064" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.912"/>
+<path d="m70.107 436.65 11.4-17.211" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.734"/>
+<path d="m81.508 419.44 11.427-17.273" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.727"/>
+<path d="m92.935 402.17 6.436-12.248" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.51"/>
+<path d="m99.371 389.92-0.277-5.472" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.79"/>
+<path d="m99.094 384.45-5.504-0.067" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.792"/>
+<path d="m93.59 384.38-7.432 1.835" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.425"/>
+<path d="m86.158 386.22-5.917 0.235" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.718"/>
+<path d="m80.241 386.45-2.199-3.573" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.025"/>
+<path d="m78.042 382.88 1.862-7.597" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.39"/>
+<path d="m79.904 375.28 4.428-10.169" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.887"/>
+<path d="m84.332 365.11 4.555-10.257" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.868"/>
+<path d="m88.887 354.86 2.522-8.164" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.274"/>
+<path d="m91.41 346.69-0.394-5.171" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.842"/>
+<path d="m91.016 341.52-2.732-2.856" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.071"/>
+<path d="m88.284 338.67-3.486-2.18" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.043"/>
+<path d="m84.798 336.49-2.46-3.304" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.04"/>
+<path d="m82.337 333.18-0.287-5.558" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.775"/>
+<path d="m82.05 327.62 1.855-7.692" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.375"/>
+<path d="m83.905 319.93 2.822-8.558" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.2"/>
+<path d="m86.727 311.38 2.217-7.796" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.344"/>
+<path d="m88.944 303.58 0.516-6.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.692"/>
+<path d="m89.46 297.57-1.242-4.201" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.989"/>
+<path d="m88.218 293.37-2.24-3.297" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.064"/>
+<path d="m85.978 290.07-2.023-3.733" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.015"/>
+<path d="m83.955 286.34-0.8-5.261" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.818"/>
+<path d="m83.155 281.08 0.835-6.944" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.527"/>
+<path d="m83.99 274.13 1.953-7.71" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.369"/>
+<path d="m85.943 266.42 2.192-7.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.469"/>
+<path d="m88.135 259.41 1.805-5.053" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.811"/>
+<path d="m89.94 254.36 1.618-2.628" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.235"/>
+<path d="m91.558 251.73 2.05-0.533" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.427"/>
+<path d="m93.608 251.2 3.31 0.616" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.184"/>
+<path d="M96.918 251.815l5.084.71" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.857"/>
+<path d="m102 252.52 6.866 0.069" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.556"/>
+<path d="m108.87 252.59 7.807-0.596" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.397"/>
+<path d="m116.68 252 7.612-0.815" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.425"/>
+<path d="m124.29 251.18 6.652-0.587" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.588"/>
+<path d="m130.94 250.6 5.284 0.13" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.83"/>
+<path d="m136.22 250.73 4.29 0.813" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.997"/>
+<path d="m140.52 251.54 3.958 1.27" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.035"/>
+<path d="m144.47 252.81 4.25 1.484" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.972"/>
+<path d="m148.72 254.29 4.325 2.042" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.92"/>
+<path d="m153.05 256.34 4.047 2.86" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.888"/>
+<path d="m157.09 259.2 3.269 3.947" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.856"/>
+<path d="m160.36 263.14 2.244 5.062" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.781"/>
+<path d="m162.61 268.2 1.071 6.16" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.654"/>
+<path d="m163.68 274.36 0.393 6.75" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.567"/>
+<path d="m164.07 281.12 0.413 6.695" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.576"/>
+<path d="m164.48 287.81 1.079 6.04" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.674"/>
+<path d="m165.56 293.85 1.755 5.339" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.766"/>
+<path d="m167.32 299.19 2.315 4.733" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.828"/>
+<path d="m169.63 303.92 2.517 4.48" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.852"/>
+<path d="m172.15 308.4 2.352 4.617" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.844"/>
+<path d="m174.5 313.02 1.754 5.25" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.781"/>
+<path d="m176.26 318.27 1.224 5.963" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.683"/>
+<path d="m177.48 324.23 1.007 6.408" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.614"/>
+<path d="m178.49 330.64 1.21 6.212" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.641"/>
+<path d="m179.7 336.85 1.493 5.436" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.762"/>
+<path d="m181.19 342.29 1.908 3.955" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.988"/>
+<path d="m183.1 346.24 2.265 1.927" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.258"/>
+<path d="m185.36 348.17 2.444-0.45" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.355"/>
+<path d="m187.81 347.72 2.17-2.616" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.175"/>
+<path d="m189.98 345.1 1.766-4.386" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.926"/>
+<path d="m191.74 340.72 1.4-5.6" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.738"/>
+<path d="m193.14 335.12 1.242-6.344" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.618"/>
+<path d="m194.39 328.77 1.125-6.48" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.598"/>
+<path d="m195.51 322.29 1.278-6.247" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.633"/>
+<path d="m196.79 316.05 1.614-5.827" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.69"/>
+<path d="m198.4 310.22 1.997-5.516" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.722"/>
+<path d="m200.4 304.7 2.036-5.194" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.773"/>
+<path d="m202.44 299.51 1.893-4.98" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.818"/>
+<path d="m204.33 294.53 1.623-4.92" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.844"/>
+<path d="m205.95 289.61 1.368-5.193" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.81"/>
+<path d="m207.32 284.42 1.063-5.485" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.771"/>
+<path d="m208.38 278.93 1.06-5.722" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.73"/>
+<path d="m209.44 273.21 1.422-5.742" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.713"/>
+<path d="m210.86 267.47 2.094-5.58" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.706"/>
+<path d="m212.96 261.89 2.765-4.844" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.774"/>
+<path d="m215.72 257.04 3.47-3.624" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.875"/>
+<path d="m219.19 253.42 4.133-2.122" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.945"/>
+<path d="m223.33 251.3 4.73-0.868" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.916"/>
+<path d="M228.056 250.43l5.14.17" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.856"/>
+<path d="m233.2 250.6 5.55 0.732" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.775"/>
+<path d="m238.74 251.33 5.96 0.789" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.702"/>
+<path d="m244.7 252.12 6.338 0.259" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.645"/>
+<path d="m251.04 252.38 6.418-0.232" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.632"/>
+<path d="m257.46 252.15 6.251-0.48" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.658"/>
+<path d="m263.71 251.67 5.822-0.312" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.734"/>
+<path d="m269.53 251.36 5.222 0.072" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.842"/>
+<path d="m274.76 251.43 4.354 0.968" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.979"/>
+<path d="m279.11 252.4 3.44 2.095" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.058"/>
+<path d="m282.55 254.49 2.545 3.276" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.034"/>
+<path d="m285.1 257.77 1.738 4.161" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.966"/>
+<path d="m286.83 261.93 0.863 5.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.854"/>
+<path d="m287.7 266.98 0.09 5.755" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.741"/>
+<path d="m287.78 272.73-0.494 6.236" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.654"/>
+<path d="m287.29 278.97-0.749 6.272" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.643"/>
+<path d="m286.54 285.24-0.778 6.25" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.646"/>
+<path d="m285.76 291.49-0.502 6.047" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.686"/>
+<path d="m285.26 297.54-0.05 5.752" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.741"/>
+<path d="m285.21 303.29 0.42 5.313" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.817"/>
+<path d="m285.63 308.6 0.589 5.205" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.833"/>
+<path d="m286.22 313.81 0.488 5.296" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.819"/>
+<path d="m286.71 319.11 0.18 5.542" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.778"/>
+<path d="m286.89 324.65-0.141 5.714" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.748"/>
+<path d="m286.74 330.36-0.42 5.984" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.698"/>
+<path d="m286.32 336.35-0.455 6.098" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.678"/>
+<path d="m285.87 342.44-0.255 6.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.695"/>
+<path d="m285.62 348.45 0.089 5.681" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.754"/>
+<path d="m285.7 354.14 0.296 5.438" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.796"/>
+<path d="m286 359.57 0.336 5.304" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.819"/>
+<path d="m286.34 364.88 0.204 5.354" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.811"/>
+<path d="m286.54 370.23 0.03 5.505" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.785"/>
+<path d="m286.57 375.74-0.167 5.855" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.723"/>
+<path d="m286.4 381.59-0.233 6.163" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.669"/>
+<path d="m286.17 387.75-0.189 6.226" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.658"/>
+<path d="m285.98 393.98-0.143 5.783" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.736"/>
+<path d="m285.84 399.76-0.42 5" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.873"/>
+<path d="m285.42 404.76-1.117 3.92" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.046"/>
+<path d="m284.3 408.68-2.27 2.729" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.147"/>
+<path d="m282.03 411.41-3.684 1.51" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.068"/>
+<path d="m278.35 412.92-5.173 0.633" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.844"/>
+<path d="m273.18 413.56-6.32 0.095" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.649"/>
+<path d="m266.86 413.65-6.8-0.228" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.567"/>
+<path d="m260.06 413.42-6.408-0.717" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.627"/>
+<path d="m253.65 412.7-5.282-1.32" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.802"/>
+<path d="m248.37 411.38-3.665-2.177" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.015"/>
+<path d="m244.7 409.21-1.94-3.23" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.105"/>
+<path d="m242.76 405.98-0.447-4.496" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.964"/>
+<path d="m242.31 401.48 0.502-5.446" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.792"/>
+<path d="m242.82 396.04 0.825-5.975" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.693"/>
+<path d="m243.64 390.06 0.661-6.07" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.679"/>
+<path d="m244.3 383.99 0.323-6.094" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.68"/>
+<path d="m244.62 377.9 0.048-5.895" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.716"/>
+<path d="m244.67 372-0.038-5.705" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.75"/>
+<path d="m244.63 366.3 0.071-5.595" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.769"/>
+<path d="m244.7 360.7 0.33-5.776" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.736"/>
+<path d="m245.04 354.92 0.488-5.77" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.735"/>
+<path d="m245.52 349.16 0.414-5.627" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.761"/>
+<path d="m245.94 343.53 0.136-5.39" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.805"/>
+<path d="m246.07 338.14-0.083-5.424" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.8"/>
+<path d="m245.99 332.72-0.174-5.447" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.795"/>
+<path d="m245.82 327.27-0.056-5.646" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.76"/>
+<path d="m245.76 321.62 0.217-5.93" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.709"/>
+<path d="m245.98 315.69 0.575-6.288" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.643"/>
+<path d="m246.55 309.4 0.672-6.013" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.689"/>
+<path d="m247.22 303.39 0.347-5.044" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.866"/>
+<path d="m247.57 298.35-0.362-3.34" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.181"/>
+<path d="m247.21 295.01-1.115-1.274" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.511"/>
+<path d="m246.1 293.73-1.77 1.224" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.419"/>
+<path d="m244.32 294.96-2.136 3.545" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.035"/>
+<path d="m242.19 298.5-2.163 5.326" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.743"/>
+<path d="m240.02 303.83-1.844 6.188" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.619"/>
+<path d="m238.18 310.02-1.55 6.549" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.572"/>
+<path d="m236.63 316.56-1.48 6.37" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.605"/>
+<path d="m235.15 322.94-1.674 5.904" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.675"/>
+<path d="m233.48 328.84-1.872 5.256" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.773"/>
+<path d="m231.6 334.1-2.057 5.02" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.8"/>
+<path d="m229.55 339.12-2.096 5.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.8"/>
+<path d="m227.45 344.12-1.967 5.153" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.784"/>
+<path d="m225.48 349.28-1.625 5.195" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.797"/>
+<path d="m223.86 354.47-1.422 5.433" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.766"/>
+<path d="m222.44 359.9-1.48 5.543" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.745"/>
+<path d="m220.96 365.45-1.772 5.53" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.732"/>
+<path d="m219.18 370.98-1.973 5.319" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.756"/>
+<path d="m217.21 376.3-2.13 5.413" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.731"/>
+<path d="m215.08 381.71-2.096 5.552" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.71"/>
+<path d="m212.98 387.26-1.909 5.627" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.709"/>
+<path d="m211.08 392.89-1.574 5.32" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.778"/>
+<path d="m209.5 398.21-1.607 4.97" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.836"/>
+<path d="m207.9 403.18-2.125 4.27" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.919"/>
+<path d="m205.77 407.45-3.13 3.274" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.964"/>
+<path d="m202.64 410.72-4.241 1.954" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.94"/>
+<path d="m198.4 412.68-5.402 0.973" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.794"/>
+<path d="m193 413.65-6.207 0.196" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.668"/>
+<path d="m186.79 413.85-6.415-0.424" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.631"/>
+<path d="m180.38 413.42-5.804-1.244" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.716"/>
+<path d="m174.57 412.18-4.776-1.955" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.852"/>
+<path d="m169.79 410.22-3.572-2.836" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.959"/>
+<path d="m166.22 407.39-2.508-3.84" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.953"/>
+<path d="m163.71 403.55-1.65-5.017" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.826"/>
+<path d="m162.06 398.53-1.36-5.673" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.727"/>
+<path d="m160.7 392.86-1.503-5.87" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.688"/>
+<path d="m159.2 386.99-1.861-5.675" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.703"/>
+<path d="m157.34 381.31-2.187-5.48" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.716"/>
+<path d="m155.15 375.83-2.183-5.219" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.759"/>
+<path d="m152.97 370.61-1.82-5.199" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.785"/>
+<path d="m151.15 365.41-1.302-5.402" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.776"/>
+<path d="m149.85 360.01-1.164-5.74" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.723"/>
+<path d="m148.68 354.27-1.326-5.778" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.711"/>
+<path d="m147.36 348.5-1.839-5.506" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.733"/>
+<path d="m145.52 342.99-2.431-5.041" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="m143.09 337.95-2.9-4.789" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="m140.19 333.16-2.68-4.768" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.793"/>
+<path d="m137.5 328.39-1.848-5.178" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.787"/>
+<path d="m135.66 323.21-0.815-5.836" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.717"/>
+<path d="m134.84 317.38-0.402-6.467" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.615"/>
+<path d="m134.44 310.91-0.69-6.323" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.635"/>
+<path d="m133.75 304.59-1.657-5.296" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.778"/>
+<path d="m132.09 299.29-2.76-3.461" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.983"/>
+<path d="m129.33 295.83-3.437-1.365" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.121"/>
+<path d="m125.9 294.46-2.844 0.928" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.256"/>
+<path d="m123.05 295.39-1.048 2.862" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.242"/>
+<path d="m122 298.25 1.223 4.291" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.974"/>
+<path d="m123.23 302.54 2.685 5.108" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.74"/>
+<path d="m125.91 307.65 2.733 5.938" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.606"/>
+<path d="m128.65 313.59 1.25 6.65" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.566"/>
+<path d="m129.9 320.24-0.986 7.145" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.491"/>
+<path d="m128.91 327.38-2.837 7.003" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.435"/>
+<path d="m126.07 334.39-2.993 6.563" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.492"/>
+<path d="m123.08 340.95-1.16 5.636" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.741"/>
+<path d="m121.92 346.59 1.828 4.565" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.892"/>
+<path d="m123.75 351.15 4.213 3.662" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.775"/>
+<path d="m127.96 354.81 4.537 3.922" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.702"/>
+<path d="m132.5 358.74 2.191 5.164" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.768"/>
+<path d="m134.69 363.9-1.967 6.963" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.487"/>
+<path d="m132.72 370.86-5.847 8.215" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.038"/>
+<path d="m126.88 379.08-6.651 8.47" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.936"/>
+<path d="m120.22 387.55-2.212 6.634" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.528"/>
+<path d="m118.01 394.18 7.911 2.477" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.321"/>
+<path d="m125.92 396.66 21.971-3.718" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.586"/>
+<path d="m147.9 392.94 36.674-10.089" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".561"/>
+<path d="m184.57 382.85 48.134-15.337" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".192"/>
+<path d="m232.7 367.52 53.066-18.066" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".107"/>
+<path d="m285.77 349.45 49.893-17.788" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".15"/>
+<path d="m335.66 331.66 39.479-14.073" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".414"/>
+<path d="m375.14 317.59 24.839-8.26" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.256"/>
+<path d="m399.98 309.33 9.983-2.037" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.028"/>
+<path d="m409.96 307.29-1.382 2.625" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.258"/>
+<path d="m408.58 309.92-6.967 5.138" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.261"/>
+<path d="m401.61 315.05-6.415 5.075" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.337"/>
+<path d="m395.2 320.13-1.493 3.179" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.153"/>
+<path d="m393.71 323.31 4.782 0.555" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.915"/>
+<path d="m398.49 323.86 9.334-0.922" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.151"/>
+<path d="m407.82 322.94 10.427-0.61" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.99"/>
+<path d="m418.25 322.33 7.892 1.435" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.365"/>
+<path d="m426.14 323.77 3.063 4.137" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.851"/>
+<path d="m429.2 327.9-2.019 6.655" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.535"/>
+<path d="m427.19 334.56-5.32 7.78" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.138"/>
+<path d="m421.87 342.34-6.029 7.09" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.157"/>
+<path d="m415.84 349.43-4.678 4.764" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.585"/>
+<path d="m411.16 354.19-2.783 2.024" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.169"/>
+<path d="m408.38 356.22-1.674-0.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.513"/>
+<path d="m406.7 355.98-2.172-1.382" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.336"/>
+<path d="m404.53 354.6-4.122-1.485" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.994"/>
+<path d="m400.41 353.11-6.664-0.715" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.584"/>
+<path d="m393.74 352.4-8.42 0.178" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.301"/>
+<path d="m385.33 352.58-8.607 0.701" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.267"/>
+<path d="m376.72 353.28-7.277 0.622" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.483"/>
+<path d="m369.44 353.9-5.249 0.467" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.833"/>
+<path d="m364.19 354.36-3.3 0.512" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.189"/>
+<path d="m360.89 354.88-2.087 1.078" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.381"/>
+<path d="m358.81 355.96-1.734 2.116" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.304"/>
+<path d="m357.07 358.07-1.948 3.667" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.033"/>
+<path d="m355.12 361.74-1.954 5.173" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.782"/>
+<path d="m353.17 366.91-1.356 6.268" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.627"/>
+<path d="m351.81 373.18-0.242 6.689" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.578"/>
+<path d="m351.57 379.87 0.83 6.712" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.566"/>
+<path d="m352.4 386.58 1.461 6.294" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.618"/>
+<path d="m353.86 392.87 1.284 5.604" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.742"/>
+<path d="m355.15 398.48 0.25 4.698" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.929"/>
+<path d="m355.4 403.18-1.421 3.93" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.027"/>
+<path d="m353.98 407.11-3.108 3.092" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.991"/>
+<path d="m350.87 410.2-4.427 2.19" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.891"/>
+<path d="m346.44 412.39-5.384 1.235" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.788"/>
+<path d="m341.06 413.62-5.78 0.486" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.739"/>
+<path d="m335.28 414.11-5.819-0.178" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.736"/>
+<path d="m329.46 413.93-5.57-0.797" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="m323.89 413.14-5.26-1.464" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.799"/>
+<path d="m318.62 411.67-4.323-2.13" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.913"/>
+<path d="m314.3 409.54-3.077-2.921" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.017"/>
+<path d="m311.22 406.62-1.688-3.817" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.028"/>
+<path d="m309.54 402.8-0.648-4.773" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.909"/>
+<path d="m308.89 398.03 0.363-5.528" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.779"/>
+<path d="m309.25 392.5 0.924-6.082" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.672"/>
+<path d="m310.18 386.42 0.998-6.372" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.62"/>
+<path d="m311.17 380.05 0.404-6.416" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.624"/>
+<path d="m311.58 373.63 0.021-6.126" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.676"/>
+<path d="m311.6 367.51-0.267-5.73" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.744"/>
+<path d="m311.33 361.78-0.351-5.38" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.805"/>
+<path d="m310.98 356.4-0.54-5.261" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.824"/>
+<path d="m310.44 351.14-0.232-5.223" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.835"/>
+<path d="m310.21 345.91 0.128-5.4" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.804"/>
+<path d="m310.34 340.51 0.393-5.702" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.748"/>
+<path d="m310.73 334.81 0.177-6.077" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.684"/>
+<path d="m310.91 328.73 0.139-6.122" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.676"/>
+<path d="m311.05 322.61 0.05-5.961" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.705"/>
+<path d="m311.1 316.65-0.02-5.664" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.757"/>
+<path d="m311.08 310.98-0.29-5.467" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.791"/>
+<path d="m310.79 305.52-0.18-5.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.832"/>
+<path d="m310.61 300.28 0.013-5.255" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.83"/>
+<path d="m310.62 295.02 0.187-5.51" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.784"/>
+<path d="m310.81 289.51 0.029-5.979" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.702"/>
+<path d="m310.84 283.54 6e-3 -6.188" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.665"/>
+<path d="m310.84 277.35-0.016-6.134" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.674"/>
+<path d="m310.83 271.21 0.097-5.735" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.744"/>
+<path d="m310.92 265.48 0.301-5.112" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.854"/>
+<path d="m311.22 260.37 1.12-4.057" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.021"/>
+<path d="m312.35 256.31 2.333-2.918" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.111"/>
+<path d="m314.68 253.39 3.756-1.843" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.03"/>
+<path d="m318.44 251.55 4.93-1.063" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.874"/>
+<path d="m323.36 250.48 5.99-0.227" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.706"/>
+<path d="m329.36 250.26 6.566 0.382" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.605"/>
+<path d="M335.921 250.64l6.629.715" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.59"/>
+<path d="M342.55 251.355l6.133.587" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.677"/>
+<path d="m348.68 251.94 5.712 0.461" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.752"/>
+<path d="m354.4 252.4 5.41 0.158" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.808"/>
+<path d="m359.8 252.56 5.338-0.191" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.821"/>
+<path d="m365.14 252.37 5.31-0.56" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.821"/>
+<path d="m370.45 251.81 5.58-0.448" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.775"/>
+<path d="m376.03 251.36 5.864-0.149" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.728"/>
+<path d="m381.9 251.21 6.052 0.18" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.695"/>
+<path d="m387.95 251.39 5.912 0.243" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.719"/>
+<path d="M393.86 251.637l5.84.304" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.731"/>
+<path d="M399.7 251.941l5.725.165" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.752"/>
+<path d="m405.42 252.11 5.54 0.015" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.785"/>
+<path d="M410.964 252.12l4.973.038" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.887"/>
+<path d="m415.94 252.16 4.36 0.799" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.985"/>
+<path d="m420.3 252.96 3.515 2.116" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.044"/>
+<path d="m423.81 255.07 2.467 3.746" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.972"/>
+<path d="m426.28 258.82 1.062 5.16" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.828"/>
+<path d="m427.34 263.98-0.096 6.175" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.667"/>
+<path d="m427.24 270.15-1.063 6.292" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.632"/>
+<path d="m426.18 276.45-1.848 5.451" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.741"/>
+<path d="m424.33 281.9-2.807 3.836" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.923"/>
+<path d="m421.52 285.73-3.568 2.106" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.037"/>
+<path d="m417.96 287.84-4.332 0.6" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.996"/>
+<path d="m413.62 288.44-5.067-0.362" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.867"/>
+<path d="m408.56 288.08-5.927-0.726" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.71"/>
+<path d="m402.63 287.35-6.326-0.529" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.645"/>
+<path d="m396.3 286.82-6.365-0.16" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.641"/>
+<path d="m389.94 286.66-6.113 0.095" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.685"/>
+<path d="m383.83 286.76-5.943 0.09" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.715"/>
+<path d="m377.88 286.85-5.575 2e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.779"/>
+<path d="m372.31 286.85-5.203 0.02" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.845"/>
+<path d="m367.1 286.87-4.755 0.424" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.922"/>
+<path d="m362.35 287.29-4.29 1.366" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.972"/>
+<path d="m358.06 288.66-3.327 2.795" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.999"/>
+<path d="m354.73 291.46-2.04 4.327" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.916"/>
+<path d="m352.69 295.78-0.648 5.424" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.793"/>
+<path d="m352.05 301.21 0.335 5.57" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.772"/>
+<path d="m352.38 306.78 0.95 4.484" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.952"/>
+<path d="m353.33 311.26 0.943 2.248" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.361"/>
+<path d="m354.27 313.51 0.47-0.666" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.691"/>
+<path d="m354.74 312.84-0.247-3.543" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.145"/>
+<path d="m354.5 309.3-0.439-5.643" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.758"/>
+<path d="m354.06 303.65 0.026-6.466" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.617"/>
+<path d="m354.08 297.19 1.16-5.914" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.693"/>
+<path d="m355.24 291.27 2.577-4.314" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.873"/>
+<path d="m357.82 286.96 4.204-2.238" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.923"/>
+<path d="m362.02 284.72 5.465-0.345" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.797"/>
+<path d="m367.49 284.38 6.148 0.888" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.668"/>
+<path d="m373.64 285.26 6.155 1.258" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.656"/>
+<path d="m379.79 286.52 6.09 0.983" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.675"/>
+<path d="m385.88 287.51 5.966 0.405" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.708"/>
+<path d="m391.85 287.91 5.904-0.119" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.721"/>
+<path d="m397.75 287.79 5.715-0.456" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.751"/>
+<path d="m403.47 287.34 5.675-0.51" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.757"/>
+<path d="m409.14 286.82 5.354-0.517" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.814"/>
+<path d="m414.49 286.31 4.656-0.775" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.932"/>
+<path d="m419.15 285.53 3.485-1.596" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.095"/>
+<path d="m422.64 283.94 2.461-2.812" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.112"/>
+<path d="m425.1 281.12 1.458-4.227" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.973"/>
+<path d="m426.55 276.9 0.531-5.45" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.791"/>
+<path d="m427.08 271.45-0.508-6.214" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.657"/>
+<path d="m426.58 265.24-1.3-5.991" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.675"/>
+<path d="m425.28 259.24-2.207-4.864" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.815"/>
+<path d="m423.07 254.38-3.246-3.12" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.97"/>
+<path d="m419.82 251.26-4.463-1.414" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.939"/>
+<path d="m415.36 249.85-5.265 0.09" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.834"/>
+<path d="m410.1 249.94-5.783 0.957" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.729"/>
+<path d="m404.31 250.89-6.003 1.114" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.686"/>
+<path d="m398.31 252.01-6.143 0.534" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.676"/>
+<path d="m392.17 252.54-5.953-0.06" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.713"/>
+<path d="m386.21 252.48-5.776-0.44" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.741"/>
+<path d="m380.44 252.04-5.684-0.436" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.757"/>
+<path d="m374.75 251.6-5.795-0.334" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.739"/>
+<path d="m368.96 251.27-5.705 0.062" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.756"/>
+<path d="m363.25 251.33-5.576 0.39" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.776"/>
+<path d="m357.68 251.72-5.46 0.475" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.796"/>
+<path d="m352.22 252.2-5.59 0.06" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.776"/>
+<path d="m346.63 252.26-5.646-0.274" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.766"/>
+<path d="m340.98 251.98-5.773-0.444" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.741"/>
+<path d="m335.21 251.54-5.854-0.278" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.729"/>
+<path d="m329.36 251.26-5.885 0.034" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.725"/>
+<path d="m323.47 251.29-5.287 0.88" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.817"/>
+<path d="m318.18 252.18-4.21 1.966" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.945"/>
+<path d="m313.97 254.14-2.799 3.128" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.025"/>
+<path d="m311.17 257.27-1.515 4.024" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.005"/>
+<path d="m309.66 261.29-0.257 4.935" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.886"/>
+<path d="m309.4 266.23 0.543 5.69" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.748"/>
+<path d="m309.94 271.92 0.806 6.228" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.649"/>
+<path d="m310.75 278.15 0.435 6.332" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.638"/>
+<path d="m311.18 284.48 0.107 6.285" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.648"/>
+<path d="m311.29 290.76-0.163 6.039" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.691"/>
+<path d="m311.13 296.8-0.244 5.705" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.749"/>
+<path d="m310.88 302.51-0.348 5.27" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.825"/>
+<path d="m310.54 307.78-0.055 5.143" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.85"/>
+<path d="m310.48 312.92 0.224 5.279" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.825"/>
+<path d="m310.71 318.2 0.353 5.607" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.765"/>
+<path d="m311.06 323.81 0.028 5.822" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.729"/>
+<path d="m311.09 329.63-0.076 6.046" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.69"/>
+<path d="m311.01 335.67-0.156 6.084" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.683"/>
+<path d="m310.85 341.76-0.142 5.93" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.71"/>
+<path d="m310.71 347.69-0.311 5.526" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.78"/>
+<path d="m310.4 353.21-0.03 5.275" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.826"/>
+<path d="m310.37 358.49 0.272 5.234" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.832"/>
+<path d="m310.64 363.72 0.453 5.437" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.794"/>
+<path d="m311.1 369.16 0.125 5.682" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.753"/>
+<path d="m311.22 374.84-0.027 6.006" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.697"/>
+<path d="m311.2 380.85-0.214 6.2" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.663"/>
+<path d="m310.98 387.05-0.288 6.128" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.675"/>
+<path d="m310.69 393.18-0.377 5.636" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.76"/>
+<path d="m310.32 398.81 0.268 4.9" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.893"/>
+<path d="m310.58 403.71 1.363 3.984" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.021"/>
+<path d="m311.95 407.7 2.752 3.009" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.048"/>
+<path d="m314.7 410.7 3.938 1.977" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.989"/>
+<path d="m318.64 412.68 5.163 1.103" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.831"/>
+<path d="M323.8 413.785l5.966.375" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.709"/>
+<path d="m329.77 414.16 6.216-0.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.666"/>
+<path d="m335.98 413.92 5.72-0.906" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.741"/>
+<path d="m341.7 413.01 5.03-1.546" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.834"/>
+<path d="m346.73 411.47 4.094-2.244" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.94"/>
+<path d="m350.83 409.22 3.01-3.016" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.014"/>
+<path d="m353.84 406.21 1.85-4.005" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.984"/>
+<path d="m355.69 402.2 0.689-4.864" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.892"/>
+<path d="m356.38 397.34-0.466-5.55" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.774"/>
+<path d="m355.91 391.79-1.38-6" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.671"/>
+<path d="m354.53 385.79-1.575-6.398" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.597"/>
+<path d="m352.96 379.39-1.057-6.406" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.613"/>
+<path d="m351.9 372.99 0.078-6.06" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.687"/>
+<path d="m351.98 366.93 1.495-5.325" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.781"/>
+<path d="m353.47 361.6 2.857-4.366" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.838"/>
+<path d="m356.33 357.23 3.693-3.005" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.923"/>
+<path d="m360.02 354.23 3.911-1.529" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.027"/>
+<path d="m363.93 352.7 3.831-0.228" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.095"/>
+<path d="m367.76 352.47 4.111 0.465" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.039"/>
+<path d="m371.87 352.94 4.958 0.704" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.88"/>
+<path d="m376.83 353.64 6.265 0.458" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.656"/>
+<path d="m383.1 354.1h7.51" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.449"/>
+<path d="m390.61 354.1 8.11-0.476" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.349"/>
+<path d="m398.72 353.62 7.43-0.511" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.459"/>
+<path d="m406.15 353.11 5.484-0.345" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.793"/>
+<path d="m411.63 352.77 2.974-0.334" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.256"/>
+<path d="m414.6 352.43 1.076-1.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.555"/>
+<path d="m415.68 351.42 0.432-2.305" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.379"/>
+<path d="m416.11 349.12 1.066-4.19" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4"/>
+<path d="m417.18 344.93 2.222-6.063" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.619"/>
+<path d="m419.4 338.87 2.825-7.263" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.396"/>
+<path d="m422.22 331.6 1.744-6.857" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.514"/>
+<path d="m423.97 324.75-1.222-5.001" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.849"/>
+<path d="m422.75 319.75-5.157-2.312" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.765"/>
+<path d="m417.59 317.43-8.285 0.011" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.323"/>
+<path d="m409.3 317.44-9.174 1.436" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.165"/>
+<path d="m400.13 318.88-7.31 1.265" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.464"/>
+<path d="m392.82 320.15-3.601-0.167" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.139"/>
+<path d="m389.22 319.98-0.115-2.014" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.445"/>
+<path d="m389.1 317.96 0.414-2.44" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.354"/>
+<path d="m389.52 315.53-4.021-0.743" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.048"/>
+<path d="m385.5 314.78-13.71 3.206" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.487"/>
+<path d="m371.79 317.99-26.8 8.333" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.117"/>
+<path d="m344.99 326.32-39.98 13.667" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".403"/>
+<path d="m305.01 339.99-49.473 17.196" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".159"/>
+<path d="m255.54 357.19-52.204 17.638" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".119"/>
+<path d="m203.33 374.82-46.892 14.372" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".222"/>
+<path d="m156.44 389.2-34.651 8.685" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".666"/>
+<path d="m121.79 397.88-18.727 1.752" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.931"/>
+<path d="m103.06 399.63-3.218-4.715" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.751"/>
+<path d="m99.845 394.92 8.215-9.548" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.678"/>
+<path d="m108.06 385.37 13.41-11.407" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.058"/>
+<path d="m121.47 373.96 12.195-10.684" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.218"/>
+<path d="m133.66 363.28 6.512-8.262" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.973"/>
+<path d="m140.18 355.02-0.505-5.656" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.754"/>
+<path d="m139.67 349.36-5.756-3.46" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.58"/>
+<path d="m133.92 345.9-7.535-2.589" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.373"/>
+<path d="m126.38 343.31-5.752-3.126" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.609"/>
+<path d="m120.63 340.19-1.843-4.85" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.843"/>
+<path d="m118.78 335.34 2.174-6.475" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.556"/>
+<path d="m120.96 328.86 4.309-7.503" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.258"/>
+<path d="m125.27 321.36 3.853-7.562" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.284"/>
+<path d="m129.12 313.8 1.427-6.911" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.517"/>
+<path d="m130.55 306.89-1.266-5.406" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.777"/>
+<path d="m129.28 301.48-2.881-3.658" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.941"/>
+<path d="m126.4 297.82-2.617-1.956" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.202"/>
+<path d="m123.79 295.87-0.75-0.563" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.666"/>
+<path d="m123.04 295.3 1.907 1.045" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.415"/>
+<path d="m124.94 296.35 3.86 2.756" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.926"/>
+<path d="m128.8 299.11 4.306 4.492" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.663"/>
+<path d="m133.11 303.6 3.248 5.836" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.582"/>
+<path d="m136.36 309.43 1.724 6.817" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.521"/>
+<path d="M138.08 316.25l.458 7.052" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.515"/>
+<path d="m138.54 323.3 0.098 6.57" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.599"/>
+<path d="m138.64 329.87 0.642 5.558" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.769"/>
+<path d="m139.28 335.43 1.883 4.738" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.859"/>
+<path d="m141.16 340.17 2.875 4.36" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.838"/>
+<path d="m144.04 344.53 3.114 4.538" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.787"/>
+<path d="m147.15 349.07 2.527 5.008" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.768"/>
+<path d="m149.68 354.07 1.754 5.653" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.713"/>
+<path d="m151.43 359.73 1.11 6.025" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.676"/>
+<path d="m152.54 365.75 0.927 5.991" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.687"/>
+<path d="m153.47 371.74 1.174 5.557" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.754"/>
+<path d="m154.64 377.3 1.81 5.221" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.782"/>
+<path d="m156.45 382.52 2.298 5.08" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.774"/>
+<path d="m158.75 387.6 2.424 5.155" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.753"/>
+<path d="m161.17 392.76 2.29 5.104" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="m163.46 397.86 2.091 5.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.793"/>
+<path d="m165.55 402.91 2.224 4.557" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.864"/>
+<path d="m167.78 407.47 2.852 3.583" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.955"/>
+<path d="m170.63 411.05 3.976 2.107" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.971"/>
+<path d="m174.6 413.16 5.025 0.902" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.863"/>
+<path d="M179.63 414.06l5.876-.058" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.726"/>
+<path d="m185.51 414 6.252-0.733" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.654"/>
+<path d="m191.76 413.27 6.067-1.466" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.663"/>
+<path d="m197.82 411.8 5.144-2" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.788"/>
+<path d="m202.97 409.8 3.88-2.699" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.929"/>
+<path d="m206.85 407.11 2.608-3.596" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.979"/>
+<path d="m209.46 403.51 1.704-4.794" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.861"/>
+<path d="m211.16 398.72 1.099-5.582" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.753"/>
+<path d="m212.26 393.13 1.024-5.964" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.689"/>
+<path d="m213.28 387.17 1.355-5.916" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.686"/>
+<path d="m214.64 381.25 1.91-5.825" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.676"/>
+<path d="m216.55 375.43 2.197-5.452" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.72"/>
+<path d="m218.75 369.98 2.245-5.153" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.766"/>
+<path d="m220.99 364.82 2.064-5.041" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.796"/>
+<path d="m223.06 359.78 1.81-5.33" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.764"/>
+<path d="m224.87 354.45 1.464-5.47" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.758"/>
+<path d="m226.33 348.98 1.355-5.472" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.762"/>
+<path d="m227.68 343.51 1.516-5.315" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.782"/>
+<path d="m229.2 338.2 1.846-5.33" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.762"/>
+<path d="m231.05 332.87 2.022-5.23" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.768"/>
+<path d="m233.07 327.64 2.077-5.26" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.759"/>
+<path d="m235.14 322.38 1.991-5.423" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.738"/>
+<path d="m237.14 316.96 1.838-5.803" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.683"/>
+<path d="m238.97 311.15 1.589-5.74" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.706"/>
+<path d="m240.56 305.41 1.485-5.156" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.811"/>
+<path d="m242.05 300.26 1.521-3.912" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.024"/>
+<path d="m243.57 296.34 1.577-2.226" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.305"/>
+<path d="M245.147 294.12l1.374.107" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.576"/>
+<path d="m246.52 294.23 0.97 2.554" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.303"/>
+<path d="m247.49 296.78 0.41 4.712" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.925"/>
+<path d="m247.9 301.49-0.16 6.077" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.684"/>
+<path d="m247.74 307.57-0.667 6.904" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.537"/>
+<path d="m247.08 314.47-0.84 7.009" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.516"/>
+<path d="m246.24 321.48-0.665 6.59" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.59"/>
+<path d="m245.57 328.07-0.281 5.799" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.732"/>
+<path d="m245.29 333.87 9e-3 5.33" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.816"/>
+<path d="m245.3 339.2 0.161 5.12" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.854"/>
+<path d="m245.46 344.32 0.13 5.183" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.842"/>
+<path d="m245.59 349.51-0.04 5.282" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.825"/>
+<path d="m245.55 354.79-0.31 5.654" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.757"/>
+<path d="m245.24 360.44-0.449 5.904" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.712"/>
+<path d="m244.79 366.35-0.413 5.971" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.701"/>
+<path d="m244.38 372.32-0.28 5.79" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.733"/>
+<path d="m244.1 378.11-0.19 5.794" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.733"/>
+<path d="m243.91 383.9-0.128 5.762" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.739"/>
+<path d="m243.78 389.66-0.057 5.636" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.762"/>
+<path d="m243.72 395.3 0.118 5.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.832"/>
+<path d="m243.84 400.54 0.536 4.766" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.913"/>
+<path d="m244.38 405.31 1.36 3.94" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.029"/>
+<path d="m245.74 409.24 2.59 2.819" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.095"/>
+<path d="m248.33 412.06 4.056 1.524" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.002"/>
+<path d="m252.38 413.59 5.406 0.535" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.804"/>
+<path d="m257.79 414.12 6.355-0.21" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.643"/>
+<path d="m264.14 413.91 6.641-0.72" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.588"/>
+<path d="m270.78 413.19 6.194-1.182" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.652"/>
+<path d="m276.98 412.01 5.01-1.572" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.836"/>
+<path d="m281.99 410.44 3.404-2.222" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.051"/>
+<path d="m285.39 408.22 1.745-3.178" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.132"/>
+<path d="m287.14 405.04 0.435-4.367" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.988"/>
+<path d="m287.57 400.67-0.413-5.377" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.805"/>
+<path d="m287.16 395.3-0.708-6.114" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.671"/>
+<path d="m286.45 389.18-0.567-6.455" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.615"/>
+<path d="m285.88 382.73-0.155-6.471" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.616"/>
+<path d="m285.73 376.26 0.173-6.107" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.679"/>
+<path d="m285.9 370.15 0.294-5.666" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.755"/>
+<path d="m286.2 364.48 0.189-5.332" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.815"/>
+<path d="m286.39 359.15 0.022-5.294" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.823"/>
+<path d="m286.41 353.86-0.173-5.349" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.813"/>
+<path d="m286.24 348.51-0.245-5.508" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.784"/>
+<path d="m285.99 343-0.163-5.684" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.753"/>
+<path d="m285.83 337.32 0.092-5.919" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.712"/>
+<path d="m285.92 331.4 0.272-5.933" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.709"/>
+<path d="m286.19 325.46 0.296-5.831" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.726"/>
+<path d="m286.49 319.63 0.13-5.663" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.757"/>
+<path d="m286.62 313.97-0.065-5.648" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.76"/>
+<path d="m286.55 308.32-0.293-5.499" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.785"/>
+<path d="m286.26 302.82-0.391-5.413" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.799"/>
+<path d="m285.87 297.41-0.291-5.428" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.798"/>
+<path d="m285.58 291.98 0.064-5.72" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="m285.64 286.26 0.383-5.853" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.721"/>
+<path d="m286.02 280.41 0.514-5.921" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.708"/>
+<path d="m286.54 274.49 0.311-5.814" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.729"/>
+<path d="m286.85 268.67-0.182-5.585" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="m286.67 263.09-1.088-4.801" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.89"/>
+<path d="m285.58 258.29-2.232-3.716" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.999"/>
+<path d="m283.35 254.57-3.432-2.47" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.021"/>
+<path d="m279.91 252.1-4.398-1.393" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.951"/>
+<path d="m275.52 250.71-5.197-0.306" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.845"/>
+<path d="m270.32 250.4-5.754 0.403" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.745"/>
+<path d="m264.56 250.81-6.088 0.664" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.683"/>
+<path d="m258.48 251.47-6.13 0.427" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.68"/>
+<path d="m252.35 251.9-6.124 0.213" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.682"/>
+<path d="m246.22 252.11-6.061-0.039" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.694"/>
+<path d="m240.16 252.07-5.915-0.16" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.719"/>
+<path d="m234.25 251.91-5.518-0.1" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.789"/>
+<path d="m228.73 251.81-4.989 0.53" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.878"/>
+<path d="m223.74 252.34-4.326 1.454" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.96"/>
+<path d="m219.41 253.79-3.58 2.556" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.989"/>
+<path d="m215.83 256.35-2.71 3.63" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.963"/>
+<path d="m213.12 259.98-2 4.828" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.836"/>
+<path d="m211.12 264.81-1.553 5.756" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.705"/>
+<path d="m209.57 270.56-1.384 6.281" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.623"/>
+<path d="m208.19 276.84-1.259 6.293" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.626"/>
+<path d="m206.93 283.14-1.295 6.102" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.657"/>
+<path d="m205.63 289.24-1.407 5.65" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.729"/>
+<path d="m204.23 294.89-1.548 5.13" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.812"/>
+<path d="m202.68 300.02-1.5 4.704" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.888"/>
+<path d="m201.18 304.72-1.549 4.752" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.877"/>
+<path d="m199.63 309.48-1.692 5.124" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.805"/>
+<path d="m197.94 314.6-1.885 5.666" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.704"/>
+<path d="m196.05 320.27-1.83 6.065" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.64"/>
+<path d="m194.22 326.33-1.73 6.253" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.614"/>
+<path d="m192.49 332.58-1.582 5.876" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.684"/>
+<path d="m190.91 338.46-1.465 4.846" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.865"/>
+<path d="m189.45 343.31-1.281 3.158" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.173"/>
+<path d="m188.16 346.46-1.39 1.242" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.477"/>
+<path d="m186.78 347.71-1.759-0.766" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.467"/>
+<path d="m185.02 346.94-2.235-2.658" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.162"/>
+<path d="m182.78 344.28-2.376-4.383" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.88"/>
+<path d="m180.41 339.9-2.268-5.63" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.687"/>
+<path d="m178.14 334.27-1.887-6.42" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.579"/>
+<path d="m176.25 327.85-1.403-6.723" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.549"/>
+<path d="m174.85 321.13-0.877-6.677" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.571"/>
+<path d="m173.97 314.45-0.819-6.132" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.666"/>
+<path d="m173.15 308.32-1.27-5.337" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.789"/>
+<path d="m171.88 302.98-2.022-4.588" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.874"/>
+<path d="m169.86 298.39-2.475-4.334" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.879"/>
+<path d="m167.38 294.06-2.555-4.52" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.843"/>
+<path d="m164.83 289.54-2.136-5.134" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.776"/>
+<path d="m162.69 284.41-1.424-5.896" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.687"/>
+<path d="m161.27 278.51-0.628-6.578" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.593"/>
+<path d="m160.64 271.93-0.53-6.513" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.605"/>
+<path d="m160.11 265.42-1.291-5.61" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.741"/>
+<path d="m158.82 259.81-2.732-4.053" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.898"/>
+<path d="m156.09 255.76-4.124-2.496" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.913"/>
+<path d="m151.96 253.26-5.26-1.117" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.814"/>
+<path d="m146.7 252.14-5.72-0.295" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.752"/>
+<path d="m140.98 251.85-5.562-0.052" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.781"/>
+<path d="m135.42 251.8-4.954-0.371" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.887"/>
+<path d="m130.47 251.42-4.79-0.511" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.914"/>
+<path d="m125.68 250.91-5.242-0.295" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.837"/>
+<path d="m120.43 250.62-6.161 0.258" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.676"/>
+<path d="m114.27 250.88-6.907 0.727" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.543"/>
+<path d="m107.36 251.6-7.045 1.047" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.513"/>
+<path d="m100.32 252.65-6.13 1.032" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.667"/>
+<path d="m94.19 253.68-4.322 0.906" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.988"/>
+<path d="m89.868 254.59-2.405 1.215" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.313"/>
+<path d="m87.463 255.8-0.825 2.173" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.384"/>
+<path d="m86.638 257.98-0.024 3.763" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.104"/>
+<path d="m86.614 261.74v5.612" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.766"/>
+<path d="m86.613 267.35-0.548 7.19" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.491"/>
+<path d="m86.065 274.54-0.917 7.889" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.37"/>
+<path d="m85.148 282.43-0.706 7.435" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.448"/>
+<path d="m84.442 289.87 0.072 6.115" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.678"/>
+<path d="m84.514 295.98 0.897 4.655" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.923"/>
+<path d="m85.41 300.64 1.364 3.818" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.05"/>
+<path d="m86.774 304.46 1.18 3.913" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.044"/>
+<path d="m87.953 308.37 0.374 4.875" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.896"/>
+<path d="m88.327 313.24-0.772 6.268" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.643"/>
+<path d="m87.555 319.51-1.622 7.406" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.43"/>
+<path d="m85.933 326.92-1.669 7.625" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.393"/>
+<path d="m84.264 334.54-0.829 6.795" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.553"/>
+<path d="m83.435 341.34 0.487 5.365" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.806"/>
+<path d="m83.922 346.7 1.65 4.022" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.996"/>
+<path d="m85.572 350.72 2.122 3.4" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.06"/>
+<path d="m87.694 354.12 1.577 3.882" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.025"/>
+<path d="m89.271 358 0.114 5.441" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.796"/>
+<path d="m89.385 363.44-1.672 7.31" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.443"/>
+<path d="m87.713 370.75-2.816 8.526" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.205"/>
+<path d="m84.897 379.28-2.598 8.327" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.245"/>
+<path d="m82.299 387.61-0.887 6.685" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.57"/>
+<path d="m81.412 394.29 1.684 4.017" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.995"/>
+<path d="m83.096 398.31 4.055 1.545" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.001"/>
+<path d="M87.15 399.854l4.953.594" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.884"/>
+<path d="m92.103 400.45 3.655 2.048" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.028"/>
+<path d="m95.758 402.5 0.652 5.077" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.854"/>
+<path d="m96.41 407.57-2.065 7.807" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.349"/>
+<path d="m94.345 415.38-1.819 7.534" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.402"/>
+<path d="m92.526 422.91 3.695 2.084" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.019"/>
+<path d="m96.22 425 15.226-9.627" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.014"/>
+<path d="m111.45 415.37 31.351-25.939" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".454"/>
+<path d="m142.8 389.43 48.229-42.968" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".034"/>
+<path d="m191.03 346.46 60.765-55.497" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="0"/>
+<path d="m251.79 290.97 64.567-59.526" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="0"/>
+<path d="m316.36 231.44 57.827-53.11" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".002"/>
+<path d="m374.18 178.33 41.864-37.66" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".102"/>
+<path d="m416.05 140.67 20.8-17.285" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.186"/>
+<path d="m436.85 123.38 0.233 2.036" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.438"/>
+<path d="m437.08 125.42-14.608 15.35" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.683"/>
+<path d="m422.47 140.77-21.025 20.069" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.042"/>
+<path d="m401.45 160.84-19.516 16.91" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.279"/>
+<path d="m381.93 177.75-12.967 8.685" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.292"/>
+<path d="m368.97 186.44-5.156-0.403" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.851"/>
+<path d="m363.81 186.03 0.504-6.783" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.56"/>
+<path d="m364.32 179.25 2.126-8.56" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.23"/>
+<path d="m366.44 170.69-0.01-6.201" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.663"/>
+<path d="m366.43 164.49-4.008-1.68" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4"/>
+<path d="m362.42 162.81-7.738 2.565" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.344"/>
+<path d="m354.68 165.38-9.809 4.743" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.922"/>
+<path d="m344.88 170.12-9.677 4.177" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.975"/>
+<path d="m335.2 174.3-7.683 1.396" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.4"/>
+<path d="m327.52 175.69-4.92-2.221" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.809"/>
+<path d="m322.6 173.47-2.666-5.115" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.74"/>
+<path d="m319.93 168.36-1.558-6.409" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.595"/>
+<path d="m318.37 161.95-1.45-6.127" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.647"/>
+<path d="m316.92 155.82-1.895-4.93" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.826"/>
+<path d="m315.03 150.89-2.433-3.68" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.985"/>
+<path d="m312.59 147.21-2.507-3.26" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.041"/>
+<path d="m310.09 143.95-1.742-4.07" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.981"/>
+<path d="m308.34 139.88-0.31-5.733" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.743"/>
+<path d="m308.04 134.14 1.174-7.253" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.468"/>
+<path d="m309.21 126.89 2.259-7.79" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.343"/>
+<path d="m311.47 119.1 2.863-7.034" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.428"/>
+<path d="m314.33 112.07 3.044-5.173" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.699"/>
+<path d="m317.38 106.89 2.955-2.77" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.053"/>
+<path d="m320.33 104.12 3.04-0.786" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.227"/>
+<path d="m323.37 103.34 3.744-0.017" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.113"/>
+<path d="m327.11 103.32 5.016-0.483" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.875"/>
+<path d="m332.13 102.84 6.315-1.442" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.622"/>
+<path d="m338.44 101.4 7.122-1.986" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.468"/>
+<path d="m345.57 99.409 7.242-1.683" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.461"/>
+<path d="M352.81 97.726l6.67-.496" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.586"/>
+<path d="m359.48 97.23 5.569 1.176" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.758"/>
+<path d="m365.05 98.406 4.644 2.338" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.845"/>
+<path d="m369.69 100.74 4.358 2.26" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.897"/>
+<path d="m374.05 103 4.787 0.962" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.903"/>
+<path d="m378.84 103.97 5.328-0.481" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.819"/>
+<path d="m384.16 103.48 5.979-1.398" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.68"/>
+<path d="m390.14 102.09 5.99-0.53" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.702"/>
+<path d="m396.13 101.56 5.278 2.428" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.737"/>
+<path d="m401.41 103.98 3.98 7.108" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.339"/>
+<path d="m405.39 111.09 3.138 11.647" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.748"/>
+<path d="m408.53 122.74 2.887 14.738" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.357"/>
+<path d="m411.42 137.48 3.228 15.324" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.278"/>
+<path d="m414.64 152.8 3.62 13.406" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.502"/>
+<path d="m418.26 166.21 3.886 9.075" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.068"/>
+<path d="m422.15 175.28 3.408 3.61" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.885"/>
+<path d="m425.56 178.89 2.144-1.748" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.298"/>
+<path d="m427.7 177.14 0.346-5.748" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.74"/>
+<path d="m428.05 171.4-1.06-8.34" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.295"/>
+<path d="m426.99 163.06-1.74-9.275" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.133"/>
+<path d="m425.25 153.78-1.533-8.844" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.205"/>
+<path d="m423.72 144.94-0.768-7.325" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.465"/>
+<path d="m422.95 137.61 0.297-5.729" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.744"/>
+<path d="m423.24 131.88 1.039-4.43" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.958"/>
+<path d="m424.28 127.45 1.185-3.816" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.061"/>
+<path d="m425.47 123.64 0.695-3.836" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.079"/>
+<path d="m426.16 119.8 0.057-4.77" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.917"/>
+<path d="m426.22 115.03-0.54-5.994" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.695"/>
+<path d="m425.68 109.04-0.944-6.889" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.534"/>
+<path d="m424.74 102.15-1.286-6.694" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.557"/>
+<path d="m423.45 95.454-1.527-5.515" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="m421.92 89.94-1.904-3.247" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.106"/>
+<path d="m420.02 86.693-2.41-0.409" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.363"/>
+<path d="m417.61 86.284-2.979 2.391" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.097"/>
+<path d="m414.63 88.675-3.137 3.986" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.865"/>
+<path d="m411.49 92.661-2.886 4.187" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.862"/>
+<path d="m408.61 96.848-2.324 3.042" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.094"/>
+<path d="m406.28 99.89-1.89 1.177" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.405"/>
+<path d="m404.39 101.07-1.635-1.117" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.454"/>
+<path d="m402.76 99.95-1.965-2.913" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.153"/>
+<path d="m400.79 97.037-2.907-3.768" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.922"/>
+<path d="m397.89 93.269-4.402-3.467" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.772"/>
+<path d="m393.48 89.802-5.642-2.698" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.659"/>
+<path d="m387.84 87.104-6.456-1.621" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.591"/>
+<path d="m381.39 85.483-6.67-0.615" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.585"/>
+<path d="m374.72 84.868-6.576 0.242" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.605"/>
+<path d="m368.14 85.11-5.933 0.481" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.713"/>
+<path d="m362.21 85.591-5.297 0.443" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.825"/>
+<path d="m356.91 86.034-4.94 0.288" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.891"/>
+<path d="m351.97 86.322-5.218 0.308" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.841"/>
+<path d="m346.75 86.63-5.458 0.154" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.799"/>
+<path d="m341.29 86.784-5.754 0.11" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="M335.54 86.894l-5.933.232" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.716"/>
+<path d="m329.61 87.126-6.167 0.701" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.669"/>
+<path d="m323.44 87.827-5.797 1.2" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.718"/>
+<path d="m317.64 89.026-5.194 1.893" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.787"/>
+<path d="m312.45 90.919-4.491 2.733" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.834"/>
+<path d="m307.96 93.652-4.086 3.722" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.785"/>
+<path d="m303.87 97.374-3.38 4.481" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.768"/>
+<path d="m300.49 101.86-2.703 5.038" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.749"/>
+<path d="m297.79 106.89-2.062 5.36" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.744"/>
+<path d="m295.73 112.25-1.707 5.59" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.726"/>
+<path d="m294.02 117.84-1.02 5.541" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.763"/>
+<path d="m293 123.38-0.352 5.487" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.786"/>
+<path d="m292.65 128.87 0.21 5.504" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.785"/>
+<path d="m292.86 134.37 0.361 5.711" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="m293.22 140.08 0.664 5.747" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.736"/>
+<path d="m293.88 145.83 0.864 5.744" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.732"/>
+<path d="m294.75 151.58 1.058 5.647" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.743"/>
+<path d="m295.8 157.22 1.175 5.529" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.759"/>
+<path d="m296.98 162.75 1.843 5.021" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.814"/>
+<path d="m298.82 167.77 2.77 4.4" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.841"/>
+<path d="m301.59 172.17 3.822 3.745" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.816"/>
+<path d="m305.42 175.92 4.63 3.248" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.763"/>
+<path d="m310.04 179.17 5.463 2.553" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.698"/>
+<path d="m315.51 181.72 5.92 1.922" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.665"/>
+<path d="m321.43 183.64 5.983 1.348" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.681"/>
+<path d="M327.411 184.99l5.632.943" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.755"/>
+<path d="m333.04 185.93 5.473 0.304" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.796"/>
+<path d="m338.52 186.24 5.413-0.252" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.807"/>
+<path d="m343.93 185.98 5.497-0.593" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.787"/>
+<path d="m349.43 185.39 5.55-0.472" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.78"/>
+<path d="m354.98 184.92 5.839-0.286" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.732"/>
+<path d="m360.82 184.63 6.012 0.083" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.702"/>
+<path d="m366.83 184.72 6 0.388" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.702"/>
+<path d="m372.83 185.1 5.699 0.464" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.754"/>
+<path d="m378.53 185.57 5.533-0.223" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.786"/>
+<path d="m384.06 185.35 5.344-1.31" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.792"/>
+<path d="m389.4 184.04 5.092-2.415" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.767"/>
+<path d="m394.5 181.62 4.538-2.934" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.808"/>
+<path d="m399.03 178.69 3.953-2.792" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.909"/>
+<path d="m402.99 175.9 3.118-1.576" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.159"/>
+<path d="m406.1 174.32 2.066 0.509" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.425"/>
+<path d="m408.17 174.83 0.757 3.031" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.227"/>
+<path d="m408.93 177.86-0.296 4.972" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.879"/>
+<path d="m408.63 182.83-1.14 6.089" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.664"/>
+<path d="m407.49 188.92-1.785 6.232" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.615"/>
+<path d="m405.71 195.15-2.52 5.681" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.662"/>
+<path d="m403.19 200.83-3.094 4.496" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.796"/>
+<path d="m400.09 205.33-3.72 3.31" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.883"/>
+<path d="m396.37 208.64-4.418 2.357" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.879"/>
+<path d="m391.95 211-5.322 1.726" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.775"/>
+<path d="m386.63 212.72-5.923 0.952" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.705"/>
+<path d="m380.71 213.68-6.225 0.163" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.665"/>
+<path d="m374.48 213.84-6.202-0.545" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.666"/>
+<path d="m368.28 213.29-6.176-0.864" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.664"/>
+<path d="m362.11 212.43-5.84-0.873" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.721"/>
+<path d="m356.27 211.56-5.465-0.375" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.796"/>
+<path d="m350.8 211.18-5.188 0.37" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.846"/>
+<path d="m345.61 211.55-5.236 1.064" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.82"/>
+<path d="m340.38 212.62-5.32 0.79" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.814"/>
+<path d="m335.06 213.4-5.434-0.44" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.801"/>
+<path d="m329.62 212.96-5.406-2.312" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.724"/>
+<path d="m324.21 210.65-5.1-3.822" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.638"/>
+<path d="m319.11 206.83-4.44-4.793" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.609"/>
+<path d="m314.67 202.04-3.637-4.582" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.727"/>
+<path d="m311.04 197.46-2.925-3.222" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.997"/>
+<path d="m308.11 194.23-2.552-0.92" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.31"/>
+<path d="m305.56 193.31-2.359 1.126" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.329"/>
+<path d="m303.2 194.44-2.268 2.566" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.171"/>
+<path d="m300.93 197.01-1.933 3.293" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.095"/>
+<path d="m299 200.3-1.06 3.87" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.058"/>
+<path d="M297.94 204.17l.652 4.15" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.022"/>
+<path d="m298.59 208.32 2.836 4.503" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.82"/>
+<path d="m301.43 212.82 4.97 4.795" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.546"/>
+<path d="m306.4 217.62 6.42 4.876" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.356"/>
+<path d="m312.82 222.49 7.002 3.979" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.358"/>
+<path d="m319.82 226.47 6.53 2.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.549"/>
+<path d="M326.35 228.713l5.414.119" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.807"/>
+<path d="m331.76 228.83 4.263-1.43" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.973"/>
+<path d="m336.03 227.4 3.955-2.096" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.976"/>
+<path d="m339.98 225.31 4.534-1.491" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.922"/>
+<path d="m344.52 223.82 5.759 0.022" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="m350.27 223.84 6.965 1.78" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.502"/>
+<path d="m357.24 225.62 7.748 2.524" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.344"/>
+<path d="m364.99 228.14 7.43 1.894" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.423"/>
+<path d="m372.42 230.04 6.054 0.078" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.695"/>
+<path d="m378.47 230.11 4.165-1.982" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.951"/>
+<path d="m382.64 228.13 2.965-3.479" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.956"/>
+<path d="m385.6 224.65 3.029-3.503" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.945"/>
+<path d="m388.63 221.15 4.595-1.982" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.88"/>
+<path d="m393.22 219.17 7.036 0.378" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.526"/>
+<path d="m400.26 219.55 9.249 1.912" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.141"/>
+<path d="m409.51 221.46 9.233 1.141" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.163"/>
+<path d="m418.74 222.6 5.454-2.916" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.671"/>
+<path d="m424.2 219.68-2.676-10.023" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.991"/>
+<path d="m421.52 209.66-13.924-19.005" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.464"/>
+<path d="m407.6 190.66-26.027-27.435" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".566"/>
+<path d="m381.57 163.22-35.706-32.73" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".232"/>
+<path d="m345.86 130.49-39.957-32.864" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".168"/>
+<path d="m305.91 97.626-36.894-27.672" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".288"/>
+<path d="m269.01 69.954-27.133-18.38" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".816"/>
+<path d="m241.88 51.574-13.296-7.658" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.325"/>
+<path d="m228.58 43.916 0.633 1.558" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.513"/>
+<path d="m229.22 45.474 10.945 6.563" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.659"/>
+<path d="m240.16 52.037 15.068 6.712" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.188"/>
+<path d="m255.23 58.75 12.78 3.173" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.606"/>
+<path d="m268.01 61.923 5.999-1.287" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.681"/>
+<path d="m274.01 60.636-1.937-4.257" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.936"/>
+<path d="m272.07 56.379-7.972-3.746" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.238"/>
+<path d="M264.1 52.633l-10.226.392" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.022"/>
+<path d="m253.87 53.025-8.639 6.843" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.902"/>
+<path d="m245.24 59.868-4.528 12.716" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.553"/>
+<path d="m240.71 72.584-0.103 15.915" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.247"/>
+<path d="m240.6 88.499 2.811 15.448" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.273"/>
+<path d="m243.42 103.95 3.51 12.088" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.675"/>
+<path d="m246.92 116.04 2.187 7.312" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.421"/>
+<path d="m249.11 123.35-0.074 3.266" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.199"/>
+<path d="m249.04 126.61-1.964 1.35" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.374"/>
+<path d="m247.08 127.96-2.392 1.901" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.242"/>
+<path d="m244.68 129.86-1.471 3.924" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.025"/>
+<path d="m243.21 133.79 0.14 6.163" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.669"/>
+<path d="m243.35 139.95 1.508 7.532" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.413"/>
+<path d="m244.86 147.48 2.02 7.725" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.364"/>
+<path d="m246.88 155.21 1.383 6.874" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.525"/>
+<path d="m248.26 162.08-0.076 5.717" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.748"/>
+<path d="m248.19 167.8-1.498 4.848" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.863"/>
+<path d="m246.69 172.65-1.882 4.539" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.892"/>
+<path d="m244.81 177.19-0.779 4.39" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.975"/>
+<path d="m244.03 181.58 1.419 3.994" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.016"/>
+<path d="m245.45 185.57 3.84 2.999" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.902"/>
+<path d="m249.29 188.57 5.463 1.441" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.765"/>
+<path d="m254.75 190.01 5.583-0.616" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.772"/>
+<path d="m260.34 189.39 3.948-2.71" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.918"/>
+<path d="m264.28 186.68 1.28-4.487" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.937"/>
+<path d="m265.56 182.2-1.175-5.66" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.737"/>
+<path d="m264.39 176.54-2.15-6.386" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.571"/>
+<path d="m262.24 170.15-1.492-6.674" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.554"/>
+<path d="m260.75 163.48 0.252-6.617" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.591"/>
+<path d="m261 156.86 1.955-6.137" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.622"/>
+<path d="m262.96 150.72 2.544-5.674" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.661"/>
+<path d="m265.5 145.05 1.419-5.163" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.812"/>
+<path d="m266.92 139.89-0.892-4.785" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.9"/>
+<path d="m266.03 135.1-2.974-4.532" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.802"/>
+<path d="m263.05 130.57-3.504-5.065" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.673"/>
+<path d="m259.55 125.5-1.768-5.958" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.661"/>
+<path d="m257.78 119.55 1.58-6.892" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.515"/>
+<path d="m259.36 112.65 4.707-7.17" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.27"/>
+<path d="m264.07 105.48 5.22-6.836" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.267"/>
+<path d="m269.29 98.648 1.382-5.113" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.823"/>
+<path d="m270.67 93.535-6.995-1.778" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.497"/>
+<path d="m263.68 91.757-18.21 3.216" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.965"/>
+<path d="m245.47 94.973-29.381 8.574" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".947"/>
+<path d="m216.09 103.55-37.182 13.585" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".498"/>
+<path d="m178.9 117.13-39.151 17.089" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".387"/>
+<path d="m139.75 134.22-34.425 18.372" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".519"/>
+<path d="m105.33 152.59-24.367 16.558" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.018"/>
+<path d="m80.962 169.15-11.607 12.37" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.129"/>
+<path d="M69.355 181.52l.636 7.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.52"/>
+<path d="m69.991 188.53 9.761 2.225" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.054"/>
+<path d="m79.752 190.76 14.085-1.154" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.481"/>
+<path d="m93.837 189.6 13.759-2.271" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.504"/>
+<path d="m107.6 187.33 10.239-1.383" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.007"/>
+<path d="m117.84 185.95 5.841 0.737" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.724"/>
+<path d="m123.68 186.68 2.312 2.41" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.187"/>
+<path d="m125.99 189.09 0.924 2.92" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.239"/>
+<path d="m126.91 192.02 1.805 2.065" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.302"/>
+<path d="M128.717 194.08l4.327.555" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.998"/>
+<path d="m133.04 194.64 6.885-1.12" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.538"/>
+<path d="m139.93 193.52 8.384-1.994" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.27"/>
+<path d="m148.31 191.52 8.312-1.747" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.289"/>
+<path d="m156.63 189.77 7.141-0.452" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.508"/>
+<path d="m163.77 189.32 5.394 0.77" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.801"/>
+<path d="m169.16 190.09 4.053 1.349" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.014"/>
+<path d="M173.214 191.44l3.694.956" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.099"/>
+<path d="m176.91 192.4 4.477 8e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.977"/>
+<path d="m181.38 192.4 5.653-1.406" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.735"/>
+<path d="m187.04 191 6.518-2.563" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.532"/>
+<path d="m193.56 188.44 6.522-3.158" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.491"/>
+<path d="m200.08 185.28 5.69-3.043" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.625"/>
+<path d="m205.77 182.23 4.152-3.085" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.849"/>
+<path d="m209.92 179.15 2.467-3.48" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.012"/>
+<path d="m212.39 175.67 1.097-4.362" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.968"/>
+<path d="m213.48 171.31 0.332-5.258" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.827"/>
+<path d="m213.82 166.05-0.086-6.255" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.654"/>
+<path d="m213.73 159.8-0.476-6.682" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.577"/>
+<path d="m213.25 153.11-1.138-6.32" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.625"/>
+<path d="m212.12 146.79-2.105-5.025" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.796"/>
+<path d="m210.01 141.77-3.36-3.711" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.877"/>
+<path d="m206.65 138.06-4.623-2.527" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.832"/>
+<path d="m202.03 135.53-5.608-1.713" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.728"/>
+<path d="m196.42 133.82-6.089-1.03" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.674"/>
+<path d="m190.33 132.79-6.133-0.882" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.671"/>
+<path d="m184.2 131.91-5.892-0.768" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.715"/>
+<path d="m178.3 131.14-5.577-0.536" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.774"/>
+<path d="m172.73 130.6-5.248 0.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.837"/>
+<path d="m167.48 130.66-5.288 0.32" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.828"/>
+<path d="m162.19 130.98-5.496 0.376" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.791"/>
+<path d="m156.7 131.35-5.771 0.211" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.744"/>
+<path d="m150.92 131.56-5.82 0.173" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.736"/>
+<path d="m145.1 131.73-6.027-0.055" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.7"/>
+<path d="m139.08 131.68-6.043-0.237" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.696"/>
+<path d="m133.04 131.44-5.859-0.379" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.727"/>
+<path d="m127.18 131.06-5.357-0.351" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.816"/>
+<path d="m121.82 130.71-5.036-0.776" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.864"/>
+<path d="m116.78 129.94-4.638-1.596" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.898"/>
+<path d="m112.14 128.34-4.037-2.75" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.901"/>
+<path d="m108.11 125.59-2.862-3.76" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.928"/>
+<path d="m105.25 121.83-1.482-4.757" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.88"/>
+<path d="m103.76 117.07 0.29-5.284" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.823"/>
+<path d="m104.05 111.79 2.263-5.145" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.766"/>
+<path d="m106.32 106.64 4.33-4.08" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.71"/>
+<path d="m110.65 102.57 5.692-2.731" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.649"/>
+<path d="m116.34 99.835 6.333-1.274" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.625"/>
+<path d="m122.67 98.56 6.296-0.048" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.654"/>
+<path d="M128.968 98.512l6.072.927" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.68"/>
+<path d="m135.04 99.44 5.545 1.113" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.765"/>
+<path d="m140.58 100.55 5.184 0.734" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.839"/>
+<path d="M145.77 101.287l5.155.038" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.854"/>
+<path d="m150.92 101.32 5.654-0.427" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.762"/>
+<path d="m156.58 100.9 6.029-0.757" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.691"/>
+<path d="m162.61 100.14 6.167-0.61" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.67"/>
+<path d="M168.775 99.53l5.918.035" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.719"/>
+<path d="m174.69 99.565 5.53 1.226" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.763"/>
+<path d="m180.22 100.79 4.77 2.302" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.827"/>
+<path d="m185 103.09 3.998 3.118" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.867"/>
+<path d="m188.99 106.21 3.439 3.44" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.903"/>
+<path d="m192.43 109.65 3.407 3.335" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.921"/>
+<path d="m195.84 112.98 3.465 2.407" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.023"/>
+<path d="m199.3 115.39 3.494 0.976" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.134"/>
+<path d="m202.8 116.37 3.213-0.748" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.197"/>
+<path d="m206.01 115.62 2.59-2.322" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.161"/>
+<path d="m208.6 113.3 1.216-3.93" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.039"/>
+<path d="m209.82 109.37-0.636-5.1" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.851"/>
+<path d="m209.18 104.27-2.63-5.603" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.666"/>
+<path d="m206.55 98.665-4.208-5.12" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.592"/>
+<path d="m202.34 93.545-5.395-4.144" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.564"/>
+<path d="m196.95 89.4-5.924-2.694" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.616"/>
+<path d="m191.02 86.706-5.91-1.15" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.701"/>
+<path d="m185.11 85.557-5.492 0.27" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.793"/>
+<path d="m179.62 85.828-5.327 0.815" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.812"/>
+<path d="m174.29 86.643-5.42 0.652" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.8"/>
+<path d="m168.87 87.295-5.738 0.022" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.75"/>
+<path d="m163.14 87.317-5.951-0.477" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.71"/>
+<path d="m157.18 86.84-6.164-0.869" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.666"/>
+<path d="m151.02 85.971-6.037-0.74" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.69"/>
+<path d="m144.98 85.232-5.635-0.173" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.768"/>
+<path d="M139.35 85.06l-5.053.675" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.864"/>
+<path d="m134.3 85.735-4.981 1.046" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.865"/>
+<path d="m129.32 86.781-5.307 0.972" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.811"/>
+<path d="M124.01 87.753l-5.886.579" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.72"/>
+<path d="m118.12 88.332-6.202 0.39" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.668"/>
+<path d="m111.92 88.722-6.327 0.407" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.646"/>
+<path d="m105.6 89.13-5.81 1.107" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.719"/>
+<path d="m99.785 90.237-4.716 2.42" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.826"/>
+<path d="m95.069 92.657-3.184 4.131" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.839"/>
+<path d="m91.885 96.788-2.098 5.303" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.751"/>
+<path d="m89.787 102.09-1.474 5.847" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.693"/>
+<path d="m88.313 107.94-1.218 5.75" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.72"/>
+<path d="m87.095 113.69-0.756 5.452" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.785"/>
+<path d="m86.339 119.14-0.13 4.91" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.892"/>
+<path d="m86.21 124.05 1.064 4.635" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.92"/>
+<path d="m87.274 128.68 2.69 4.617" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.815"/>
+<path d="m89.965 133.3 4.545 4.746" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.603"/>
+<path d="m94.51 138.05 5.636 4.175" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.529"/>
+<path d="m100.15 142.22 5.85 2.981" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.606"/>
+<path d="m106 145.2 5.347 1.36" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.789"/>
+<path d="m111.34 146.56 4.807-0.057" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.917"/>
+<path d="m116.15 146.51 4.524-1.095" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.944"/>
+<path d="m120.67 145.41 4.944-1.2" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.866"/>
+<path d="m125.62 144.21 5.911-0.48" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.717"/>
+<path d="M131.53 143.732l6.773.552" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.568"/>
+<path d="m138.3 144.28 7.107 1.148" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5"/>
+<path d="m145.41 145.43 6.674 1.09" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.574"/>
+<path d="m152.08 146.52 5.678 0.406" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.758"/>
+<path d="m157.76 146.93 4.542-0.493" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.96"/>
+<path d="m162.3 146.44 4.026-1.233" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.025"/>
+<path d="m166.33 145.2 4.438-1.161" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.956"/>
+<path d="m170.77 144.04 5.543-0.175" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.784"/>
+<path d="m176.31 143.87 6.516 1.448" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.589"/>
+<path d="m182.83 145.31 6.706 2.937" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.479"/>
+<path d="m189.53 148.25 5.677 4.049" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.536"/>
+<path d="m195.21 152.3 3.462 4.56" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.749"/>
+<path d="m198.67 156.86 0.439 4.545" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.955"/>
+<path d="m199.11 161.4-2.4 4.041" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.932"/>
+<path d="m196.71 165.45-4.265 3.565" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.779"/>
+<path d="m192.44 169.01-4.867 3.272" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.726"/>
+<path d="m187.58 172.28-4.658 3.117" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.772"/>
+<path d="m182.92 175.4-4.147 2.62" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.897"/>
+<path d="m178.77 178.02-3.937 1.81" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.002"/>
+<path d="m174.84 179.83-4.458 0.663" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.971"/>
+<path d="m170.38 180.49-5.848-0.57" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.726"/>
+<path d="m164.53 179.92-7.46-1.758" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.423"/>
+<path d="m157.07 178.17-8.37-2.204" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.264"/>
+<path d="m148.7 175.96-7.945-1.612" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.352"/>
+<path d="m140.76 174.35-6.268-0.035" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.658"/>
+<path d="m134.49 174.32-3.96 1.619" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.013"/>
+<path d="m130.53 175.93-2.03 2.672" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.184"/>
+<path d="m128.5 178.61-1.687 2.27" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.285"/>
+<path d="m126.81 180.88-3.631 0.113" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.134"/>
+<path d="m123.18 180.99-7.264-3.52" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.356"/>
+<path d="m115.92 177.47-10.456-6.963" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.685"/>
+<path d="m105.46 170.51-10.525-8.232" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.577"/>
+<path d="m94.934 162.28-5.24-5.573" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.422"/>
+<path d="m89.694 156.7 6.099 1.361" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.661"/>
+<path d="m95.793 158.06 22.173 11.669" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.343"/>
+<path d="m117.97 169.73 39.296 22.74" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".308"/>
+<path d="m157.26 192.47 52.594 31.252" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".056"/>
+<path d="m209.86 223.72 57.81 34.134" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".023"/>
+<path d="m267.67 257.86 53.21 30.315" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".056"/>
+<path d="m320.88 288.17 40.01 20.783" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".317"/>
+<path d="m360.89 308.96 22.115 8.468" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.46"/>
+<path d="m383 317.42 4.703-3.13" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.764"/>
+<path d="m387.7 314.3-7.416-10.706" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.619"/>
+<path d="m380.29 303.59-11.794-12.775" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.081"/>
+<path d="m368.49 290.82-8.908-9.885" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.582"/>
+<path d="m359.59 280.93-1.608-4.36" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.941"/>
+<path d="m357.98 276.57 6.45 1.25" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.606"/>
+<path d="m364.43 277.82 12.078 4.824" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.627"/>
+<path d="m376.51 282.64 13.674 5.503" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.402"/>
+<path d="m390.18 288.15 11.573 3.659" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.747"/>
+<path d="m401.75 291.81 7.56 0.777" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.434"/>
+<path d="m409.31 292.58 3.693-1.71" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.051"/>
+<path d="m413.01 290.87 1.371-2.996" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.194"/>
+<path d="m414.38 287.88 1.023-3.089" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.202"/>
+<path d="m415.4 284.79 2.116-2.477" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.203"/>
+<path d="m417.52 282.31 3.54-1.982" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.053"/>
+<path d="m421.06 280.33 4.19-2.272" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.923"/>
+<path d="m425.25 278.06 3.51-3.41" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.898"/>
+<path d="m428.76 274.65 1.658-4.882" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.848"/>
+<path d="m430.42 269.76-0.788-5.99" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.691"/>
+<path d="m429.63 263.78-3.125-6.238" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.532"/>
+<path d="m426.5 257.54-4.787-5.28" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.508"/>
+<path d="m421.72 252.26-5.444-3.27" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.642"/>
+<path d="m416.27 248.99-5.27-0.828" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.822"/>
+<path d="m411 248.16-4.768 1.122" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.9"/>
+<path d="m406.24 249.28-4.542 2.084" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.881"/>
+<path d="m401.69 251.37-4.767 1.918" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.856"/>
+<path d="m396.93 253.28-5.434 0.904" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.791"/>
+<path d="m391.49 254.19-6.266-0.524" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.655"/>
+<path d="m385.23 253.66-6.947-1.5" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.516"/>
+<path d="m378.28 252.16-6.981-1.552" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.508"/>
+<path d="m371.3 250.61-6.33-0.71" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.641"/>
+<path d="m364.97 249.9-5.326 0.366" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.821"/>
+<path d="m359.64 250.27-4.622 1.195" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.922"/>
+<path d="m355.02 251.46-4.428 1.355" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.948"/>
+<path d="m350.59 252.82-4.866 0.777" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.895"/>
+<path d="m345.73 253.59-5.79-0.378" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.739"/>
+<path d="m339.94 253.22-6.688-1.258" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.566"/>
+<path d="m333.25 251.96-6.93-1.28" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.526"/>
+<path d="m326.32 250.68-6.228-0.26" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.664"/>
+<path d="m320.09 250.42-4.905 1.267" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.869"/>
+<path d="m315.19 251.68-2.996 3.122" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.002"/>
+<path d="m312.19 254.81-1.263 4.574" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.923"/>
+<path d="m310.93 259.38-0.12 5.333" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.816"/>
+<path d="m310.81 264.71 0.14 5.307" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.82"/>
+<path d="m310.95 270.02 0.135 5.219" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.836"/>
+<path d="m311.08 275.24-0.035 5.32" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.818"/>
+<path d="m311.05 280.56-0.124 5.739" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.744"/>
+<path d="m310.92 286.3-0.233 6.136" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.673"/>
+<path d="m310.69 292.44 0.037 6.47" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.616"/>
+<path d="m310.73 298.9 0.308 6.397" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.628"/>
+<path d="m311.04 305.3 0.428 5.912" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.711"/>
+<path d="m311.46 311.21 0.108 5.12" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.854"/>
+<path d="m311.57 316.34-0.032 4.696" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.931"/>
+<path d="m311.54 321.03-0.173 4.806" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.911"/>
+<path d="m311.37 325.84-0.23 5.413" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.801"/>
+<path d="m311.14 331.25-0.444 6.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.687"/>
+<path d="m310.69 337.3-0.194 6.563" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.6"/>
+<path d="m310.5 343.86 0.133 6.578" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.598"/>
+<path d="m310.63 350.44 0.41 6.089" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.68"/>
+<path d="M311.04 356.53l.231 5.241" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.831"/>
+<path d="m311.27 361.77 0.245 4.704" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.929"/>
+<path d="m311.52 366.48 0.135 4.728" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.925"/>
+<path d="m311.65 371.2-0.053 5.324" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.817"/>
+<path d="m311.6 376.53-0.526 6.067" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.682"/>
+<path d="m311.07 382.59-0.505 6.65" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.582"/>
+<path d="m310.57 389.24-0.208 6.652" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.585"/>
+<path d="m310.36 395.9 0.372 5.948" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.705"/>
+<path d="m310.73 401.84 0.911 4.622" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.928"/>
+<path d="m311.64 406.47 1.926 3.21" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.11"/>
+<path d="m313.57 409.68 3.047 2.048" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.125"/>
+<path d="m316.62 411.72 4.151 1.316" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.999"/>
+<path d="M320.766 413.04l4.891.841" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.888"/>
+<path d="m325.66 413.88 5.659 0.52" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.76"/>
+<path d="M331.316 414.4l6.101.06" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.687"/>
+<path d="m337.42 414.46 6.077-0.674" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.685"/>
+<path d="m343.49 413.79 5.31-1.744" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.776"/>
+<path d="m348.8 412.04 4.183-2.807" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.873"/>
+<path d="m352.99 409.24 2.674-3.718" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.954"/>
+<path d="m355.66 405.52 1.066-4.4" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.962"/>
+<path d="m356.73 401.12-0.226-5.081" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.86"/>
+<path d="m356.5 396.04-1.022-5.553" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.76"/>
+<path d="m355.48 390.48-1.286-5.917" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.688"/>
+<path d="m354.19 384.57-1.049-6.145" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.657"/>
+<path d="m353.14 378.42-0.262-6.323" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.641"/>
+<path d="M352.88 372.1l.715-6.014" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.688"/>
+<path d="m353.6 366.09 1.663-5.22" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.791"/>
+<path d="m355.26 360.87 2.45-3.993" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.935"/>
+<path d="m357.71 356.87 3.16-2.683" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.036"/>
+<path d="m360.87 354.19 3.726-1.282" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.075"/>
+<path d="m364.59 352.91 4.22-0.15" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.023"/>
+<path d="m368.82 352.76 4.783 0.536" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.915"/>
+<path d="m373.6 353.3 5.646 0.593" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.761"/>
+<path d="m379.24 353.89 6.568 0.419" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.605"/>
+<path d="m385.81 354.31 7.237 0.089" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.494"/>
+<path d="m393.05 354.4 7.302-0.201" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.483"/>
+<path d="m400.35 354.2 6.655-0.478" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.589"/>
+<path d="m407.01 353.72 5.204-0.537" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.84"/>
+<path d="M412.21 353.18l3.299-.751" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.181"/>
+<path d="m415.51 352.43 1.58-1.392" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.428"/>
+<path d="m417.09 351.04 0.789-2.713" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.285"/>
+<path d="m417.88 348.32 0.953-4.285" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.988"/>
+<path d="m418.83 344.04 1.61-5.843" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.688"/>
+<path d="m420.44 338.2 1.887-6.775" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.521"/>
+<path d="m422.33 331.42 1.058-6.688" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.565"/>
+<path d="m423.39 324.73-1.313-5.063" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.835"/>
+<path d="m422.07 319.67-4.71-2.523" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.819"/>
+<path d="m417.36 317.15-7.805 0.038" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.401"/>
+<path d="m409.56 317.18-8.978 1.45" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.195"/>
+<path d="m400.58 318.64-7.55 1.58" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.415"/>
+<path d="m393.03 320.22-4.125 0.305" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.039"/>
+<path d="m388.9 320.52-0.668-1.46" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.528"/>
+<path d="m388.24 319.06 0.258-2.555" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.335"/>
+<path d="m388.5 316.5-3.646-1.25" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.092"/>
+<path d="m384.85 315.26-13.059 2.566" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.588"/>
+<path d="m371.79 317.82-26.39 8.149" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.148"/>
+<path d="m345.4 325.97-40.07 13.59" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".401"/>
+<path d="m305.33 339.56-49.933 17.506" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".151"/>
+<path d="m255.4 357.07-52.718 18.092" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".111"/>
+<path d="m202.68 375.16-47.171 14.899" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".213"/>
+<path d="m155.51 390.06-34.545 8.473" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".673"/>
+<path d="m120.96 398.53-18.251 1.163" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.987"/>
+<path d="m102.71 399.69-2.733-5.34" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.7"/>
+<path d="m99.98 394.35 8.302-9.559" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.669"/>
+<path d="m108.28 384.79 12.987-11.231" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.107"/>
+<path d="m121.27 373.56 11.632-10.19" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.308"/>
+<path d="m132.9 363.37 6.203-7.773" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.059"/>
+<path d="m139.1 355.6-0.353-5.232" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.832"/>
+<path d="m138.75 350.37-5.3-3.782" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.614"/>
+<path d="m133.45 346.59-6.982-3.265" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.415"/>
+<path d="m126.47 343.32-5.488-3.766" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.59"/>
+<path d="m120.98 339.56-2.048-4.841" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.83"/>
+<path d="m118.93 334.71 1.515-6.222" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.628"/>
+<path d="m120.45 328.49 3.759-6.981" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.374"/>
+<path d="m124.21 321.51 3.773-7.117" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.354"/>
+<path d="m127.98 314.39 1.893-6.605" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.549"/>
+<path d="m129.87 307.79-0.728-5.763" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.732"/>
+<path d="m129.14 302.03-2.484-4.263" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.889"/>
+<path d="m126.66 297.76-2.647-2.456" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.136"/>
+<path d="m124.02 295.31-1.153-0.493" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.601"/>
+<path d="m122.86 294.81 1.201 1.294" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.496"/>
+<path d="m124.06 296.11 3.504 3.173" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.929"/>
+<path d="m127.57 299.28 4.526 4.798" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.598"/>
+<path d="m132.09 304.08 3.943 6.005" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.497"/>
+<path d="m136.04 310.08 2.203 6.526" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.546"/>
+<path d="M138.24 316.61l.58 6.657" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.58"/>
+<path d="m138.82 323.27-0.24 6.324" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.641"/>
+<path d="M138.58 329.59l.114 5.717" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.748"/>
+<path d="m138.69 335.31 1.293 4.976" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.851"/>
+<path d="m139.99 340.28 2.795 4.608" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.807"/>
+<path d="m142.78 344.89 3.59 4.616" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.727"/>
+<path d="m146.37 349.51 3.3 4.956" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.708"/>
+<path d="m149.67 354.46 2.123 5.345" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.742"/>
+<path d="m151.8 359.81 0.992 5.772" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.723"/>
+<path d="m152.79 365.58 0.39 5.94" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.706"/>
+<path d="m153.18 371.52 0.616 5.81" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.725"/>
+<path d="m153.8 377.33 1.427 5.401" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.771"/>
+<path d="m155.22 382.73 2.446 5.159" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.75"/>
+<path d="m157.67 387.89 2.988 5.068" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.72"/>
+<path d="m160.66 392.96 2.846 5.079" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.731"/>
+<path d="m163.5 398.04 2.354 4.822" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.811"/>
+<path d="m165.86 402.86 1.9 4.508" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.896"/>
+<path d="m167.76 407.37 2.146 3.756" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4"/>
+<path d="m169.9 411.12 3.23 2.604" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.035"/>
+<path d="m173.13 413.73 4.888 1.077" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.88"/>
+<path d="m178.02 414.8 6.206-0.06" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.669"/>
+<path d="m184.23 414.74 6.813-0.865" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.556"/>
+<path d="m191.04 413.88 6.457-1.376" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.601"/>
+<path d="m197.5 412.5 5.35-2.009" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.754"/>
+<path d="m202.85 410.5 3.722-2.544" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.969"/>
+<path d="m206.57 407.95 2.288-3.32" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.056"/>
+<path d="m208.86 404.63 1.43-4.297" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.962"/>
+<path d="m210.29 400.33 1.294-5.49" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.761"/>
+<path d="m211.58 394.84 1.42-6.133" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.647"/>
+<path d="m213 388.71 1.705-6.234" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.618"/>
+<path d="m214.7 382.48 1.918-5.852" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.671"/>
+<path d="m216.62 376.62 2.014-5.5" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.724"/>
+<path d="m218.64 371.12 1.813-5.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.811"/>
+<path d="m220.45 366.07 1.633-4.876" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.851"/>
+<path d="m222.08 361.2 1.59-5.013" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.83"/>
+<path d="m223.67 356.18 1.733-5.54" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.733"/>
+<path d="m225.41 350.64 1.806-5.78" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.689"/>
+<path d="m227.21 344.86 1.899-5.693" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.698"/>
+<path d="m229.11 339.17 1.958-5.32" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.757"/>
+<path d="m231.07 333.85 1.963-5.127" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.789"/>
+<path d="m233.03 328.73 1.801-4.957" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.827"/>
+<path d="m234.83 323.77 1.693-5.105" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.808"/>
+<path d="m236.53 318.66 1.689-5.479" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.745"/>
+<path d="m238.22 313.18 1.778-5.972" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.658"/>
+<path d="m239.99 307.21 1.762-5.741" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.698"/>
+<path d="m241.76 301.47 1.715-4.66" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.883"/>
+<path d="m243.47 296.81 1.582-2.706" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.226"/>
+<path d="m245.05 294.11 1.322-0.361" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.577"/>
+<path d="m246.37 293.74 0.827 2.302" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.359"/>
+<path d="m247.2 296.05 0.309 4.575" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.951"/>
+<path d="m247.51 300.62-0.127 6.095" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.681"/>
+<path d="m247.38 306.72-0.399 6.595" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.593"/>
+<path d="m246.98 313.31-0.576 6.652" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.581"/>
+<path d="m246.41 319.96-0.535 6.336" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.636"/>
+<path d="m245.87 326.3-0.34 5.926" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.709"/>
+<path d="m245.53 332.23-0.103 5.456" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.794"/>
+<path d="m245.43 337.68-0.02 5.39" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.806"/>
+<path d="m245.41 343.07-0.023 5.434" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.798"/>
+<path d="m245.39 348.51-0.084 5.496" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.787"/>
+<path d="m245.3 354-0.17 5.399" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.804"/>
+<path d="m245.13 359.4-0.298 5.537" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.778"/>
+<path d="m244.84 364.94-0.33 5.671" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.754"/>
+<path d="m244.5 370.61-0.28 5.802" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.731"/>
+<path d="m244.22 376.41-0.22 5.81" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.731"/>
+<path d="m244 382.22-0.221 5.974" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.702"/>
+<path d="m243.78 388.2-0.194 5.94" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.708"/>
+<path d="m243.59 394.14-0.038 5.605" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.768"/>
+<path d="M243.55 399.74l.356 4.863" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.898"/>
+<path d="m243.91 404.6 1.077 4.052" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.024"/>
+<path d="m244.98 408.66 2.188 3.041" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.109"/>
+<path d="m247.17 411.7 3.582 1.956" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.049"/>
+<path d="m250.75 413.65 5.013 0.873" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.866"/>
+<path d="m255.77 414.52 6.1 0.138" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.687"/>
+<path d="m261.87 414.66 6.61-0.436" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.597"/>
+<path d="m268.48 414.23 6.39-0.939" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.625"/>
+<path d="m274.87 413.29 5.5-1.538" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.755"/>
+<path d="m280.37 411.75 4.05-2.135" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.957"/>
+<path d="m284.42 409.62 2.41-2.938" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.1"/>
+<path d="m286.83 406.68 0.925-3.914" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.056"/>
+<path d="m287.75 402.76-0.077-4.973" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.881"/>
+<path d="m287.68 397.79-0.602-5.752" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.736"/>
+<path d="m287.07 392.04-0.653-6.233" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.651"/>
+<path d="m286.42 385.8-0.4-6.37" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.632"/>
+<path d="m286.02 379.44v-6.277" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.65"/>
+<path d="m286.02 373.16 0.252-5.903" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.714"/>
+<path d="m286.27 367.26 0.293-5.518" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.782"/>
+<path d="m286.56 361.74 0.148-5.266" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.827"/>
+<path d="m286.71 356.47-9e-3 -5.304" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.821"/>
+<path d="m286.7 351.17-0.169-5.41" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.802"/>
+<path d="m286.54 345.76-0.218-5.585" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="m286.32 340.17-0.143-5.747" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.742"/>
+<path d="m286.17 334.43 0.078-5.956" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.706"/>
+<path d="m286.25 328.47 0.223-5.925" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.71"/>
+<path d="m286.48 322.55 0.236-5.788" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.734"/>
+<path d="m286.71 316.76 0.098-5.601" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.768"/>
+<path d="m286.81 311.16-0.046-5.598" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.769"/>
+<path d="m286.76 305.56-0.226-5.475" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.79"/>
+<path d="m286.54 300.08-0.308-5.43" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.797"/>
+<path d="m286.23 294.66-0.23-5.486" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.788"/>
+<path d="M286 289.17l.075-5.8" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.733"/>
+<path d="m286.08 283.37 0.334-5.914" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.711"/>
+<path d="m286.41 277.46 0.408-5.916" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.71"/>
+<path d="m286.82 271.54 0.147-5.698" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.751"/>
+<path d="m286.96 265.84-0.418-5.322" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.815"/>
+<path d="m286.55 260.52-1.425-4.375" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.949"/>
+<path d="m285.12 256.14-2.691-3.156" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.035"/>
+<path d="m282.43 252.99-3.999-1.845" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.989"/>
+<path d="m278.43 251.14-5.008-0.8" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.869"/>
+<path d="m273.42 250.34-5.749 0.158" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.748"/>
+<path d="m267.67 250.5-6.138 0.658" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.675"/>
+<path d="m261.54 251.16-6.237 0.692" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.657"/>
+<path d="m255.3 251.85-6.046 0.274" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.696"/>
+<path d="m249.25 252.13-5.88-0.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.726"/>
+<path d="m243.37 252.12-5.761-0.203" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.746"/>
+<path d="m237.61 251.91-5.657-0.157" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.764"/>
+<path d="m231.96 251.76-5.337 0.127" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.821"/>
+<path d="m226.62 251.88-4.851 0.958" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.891"/>
+<path d="m221.77 252.84-4.162 2" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.95"/>
+<path d="m217.6 254.84-3.332 3.114" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.959"/>
+<path d="m214.27 257.96-2.368 4.105" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.925"/>
+<path d="m211.9 262.06-1.627 5.157" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.803"/>
+<path d="m210.28 267.22-1.25 5.928" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.688"/>
+<path d="m209.03 273.15-1.244 6.32" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.622"/>
+<path d="m207.78 279.47-1.314 6.238" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.633"/>
+<path d="m206.47 285.7-1.498 5.988" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.668"/>
+<path d="m204.97 291.69-1.653 5.51" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.742"/>
+<path d="m203.32 297.2-1.72 4.998" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.825"/>
+<path d="m201.6 302.2-1.524 4.62" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.901"/>
+<path d="m200.08 306.82-1.427 4.746" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.884"/>
+<path d="m198.65 311.57-1.497 5.21" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.801"/>
+<path d="m197.15 316.78-1.716 5.824" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.686"/>
+<path d="m195.44 322.6-1.761 6.227" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.617"/>
+<path d="m193.68 328.83-1.782 6.314" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.601"/>
+<path d="m191.89 335.14-1.712 5.735" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.701"/>
+<path d="m190.18 340.88-1.601 4.44" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.928"/>
+<path d="m188.58 345.32-1.358 2.488" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.284"/>
+<path d="m187.22 347.8-1.38 0.39" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.565"/>
+<path d="m185.84 348.19-1.685-1.66" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.377"/>
+<path d="m184.16 346.53-2.145-3.438" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.051"/>
+<path d="m182.01 343.1-2.318-4.933" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.796"/>
+<path d="m179.69 338.16-2.261-5.901" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.643"/>
+<path d="m177.43 332.26-1.923-6.438" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.574"/>
+<path d="m175.51 325.82-1.453-6.572" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.572"/>
+<path d="m174.06 319.25-0.912-6.462" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.607"/>
+<path d="m173.14 312.79-0.831-5.943" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.698"/>
+<path d="m172.31 306.85-1.267-5.229" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.808"/>
+<path d="m171.05 301.62-2.017-4.565" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.878"/>
+<path d="m169.03 297.05-2.475-4.37" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.873"/>
+<path d="m166.56 292.68-2.555-4.574" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.834"/>
+<path d="m164 288.11-2.125-5.168" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.771"/>
+<path d="m161.87 282.94-1.396-5.886" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.69"/>
+<path d="m160.48 277.06-0.593-6.518" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.604"/>
+<path d="m159.88 270.54-0.529-6.402" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.624"/>
+<path d="m159.36 264.14-1.359-5.455" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.765"/>
+<path d="m158 258.68-2.893-3.862" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.91"/>
+<path d="m155.1 254.82-4.367-2.28" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.894"/>
+<path d="m150.74 252.54-5.546-0.884" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.772"/>
+<path d="m145.19 251.66-5.986-0.067" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.707"/>
+<path d="m139.2 251.59-5.75 0.148" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.748"/>
+<path d="m133.46 251.74-5.033-0.226" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.875"/>
+<path d="m128.42 251.51-4.772-0.439" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.919"/>
+<path d="m123.65 251.07-5.162-0.298" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.851"/>
+<path d="m118.49 250.78-6.065 0.198" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.693"/>
+<path d="m112.42 250.97-6.822 0.65" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.559"/>
+<path d="m105.6 251.62-6.972 1.007" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.526"/>
+<path d="m98.628 252.63-6.047 1.074" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.68"/>
+<path d="m92.58 253.7-4.195 1.058" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.004"/>
+<path d="m88.385 254.76-2.217 1.465" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.32"/>
+<path d="m86.168 256.23-0.587 2.484" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.338"/>
+<path d="m85.581 258.71 0.233 4.073" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.045"/>
+<path d="m85.814 262.78 0.221 5.852" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.723"/>
+<path d="m86.035 268.64-0.402 7.31" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.472"/>
+<path d="m85.633 275.94-0.869 7.88" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.373"/>
+<path d="m84.764 283.82-0.747 7.32" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.467"/>
+<path d="m84.017 291.14-0.023 5.949" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.707"/>
+<path d="m83.994 297.09 0.794 4.504" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.954"/>
+<path d="m84.788 301.6 1.294 3.739" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.069"/>
+<path d="m86.082 305.34 1.162 3.931" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.042"/>
+<path d="m87.244 309.27 0.41 4.972" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.878"/>
+<path d="m87.653 314.24-0.706 6.397" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.622"/>
+<path d="m86.947 320.64-1.556 7.504" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.416"/>
+<path d="m85.391 328.14-1.63 7.648" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.39"/>
+<path d="m83.762 335.79-0.828 6.734" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.563"/>
+<path d="m82.934 342.52 0.454 5.25" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.827"/>
+<path d="m83.388 347.77 1.6 3.908" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.019"/>
+<path d="m84.988 351.68 2.075 3.345" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.073"/>
+<path d="m87.063 355.02 1.553 3.916" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.021"/>
+<path d="M88.616 358.94l.117 5.552" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.777"/>
+<path d="m88.733 364.49-1.65 7.44" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.423"/>
+<path d="m87.083 371.93-2.788 8.607" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.194"/>
+<path d="m84.295 380.54-2.574 8.313" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.249"/>
+<path d="m81.721 388.85-0.87 6.57" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.59"/>
+<path d="m80.851 395.42 1.702 3.845" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.023"/>
+<path d="m82.553 399.27 4.085 1.385" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.006"/>
+<path d="M86.638 400.651l5.002.505" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.877"/>
+<path d="m91.64 401.16 3.724 2.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.017"/>
+<path d="m95.364 403.21 0.722 5.136" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.842"/>
+<path d="m96.086 408.34-2.008 7.86" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.343"/>
+<path d="m94.078 416.2-1.783 7.517" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.406"/>
+<path d="m92.295 423.72 3.721 1.972" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.024"/>
+<path d="m96.016 425.69 15.264-9.81" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.999"/>
+<path d="m111.28 415.88 31.428-26.139" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".447"/>
+<path d="m142.71 389.74 48.356-43.124" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".033"/>
+<path d="m191.06 346.62 60.933-55.583" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="0"/>
+<path d="m252 291.03 64.733-59.557" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="0"/>
+<path d="m316.73 231.48 57.948-53.137" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".002"/>
+<path d="m374.68 178.34 41.91-37.727" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".102"/>
+<path d="m416.59 140.61 20.775-17.407" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.182"/>
+<path d="m437.36 123.21 0.167 1.892" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.468"/>
+<path d="m437.53 125.1-14.664 15.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.687"/>
+<path d="m422.87 140.34-21.031 20.044" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.043"/>
+<path d="m401.84 160.38-19.46 16.982" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.279"/>
+<path d="m382.38 177.36-12.877 8.819" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.292"/>
+<path d="m369.5 186.18-5.077-0.284" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.866"/>
+<path d="m364.42 185.9 0.53-6.743" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.566"/>
+<path d="m364.95 179.15 2.088-8.611" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.223"/>
+<path d="m367.04 170.54-0.094-6.328" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.641"/>
+<path d="m366.94 164.21-4.094-1.819" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.975"/>
+<path d="m362.85 162.4-7.78 2.483" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.341"/>
+<path d="m355.07 164.88-9.786 4.768" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.924"/>
+<path d="m345.28 169.65-9.602 4.312" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.977"/>
+<path d="m335.68 173.96-7.597 1.597" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.407"/>
+<path d="m328.08 175.56-4.873-2.028" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.831"/>
+<path d="m323.21 173.53-2.693-5.003" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.755"/>
+<path d="m320.52 168.52-1.657-6.411" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.591"/>
+<path d="m318.86 162.11-1.588-6.23" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.624"/>
+<path d="m317.28 155.88-2.017-5.07" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.795"/>
+<path d="m315.26 150.81-2.495-3.774" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.964"/>
+<path d="m312.76 147.04-2.49-3.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.046"/>
+<path d="m310.27 143.8-1.666-3.925" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.012"/>
+<path d="m308.61 139.87-0.225-5.52" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.782"/>
+<path d="m308.38 134.36 1.21-7.082" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.495"/>
+<path d="m309.59 127.27 2.204-7.769" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.349"/>
+<path d="m311.79 119.5 2.712-7.214" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.409"/>
+<path d="m314.51 112.29 2.832-5.51" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.665"/>
+<path d="m317.34 106.78 2.741-3.136" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.031"/>
+<path d="m320.08 103.64 2.885-1.017" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.243"/>
+<path d="m322.96 102.63 3.683-0.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.124"/>
+<path d="m326.65 102.62 5.039-0.257" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.873"/>
+<path d="m331.69 102.36 6.374-1.143" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.622"/>
+<path d="m338.06 101.22 7.156-1.822" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.469"/>
+<path d="m345.22 99.394 7.204-1.812" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.462"/>
+<path d="m352.42 97.582 6.558-0.926" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.597"/>
+<path d="M358.98 96.656l5.426.629" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.799"/>
+<path d="m364.41 97.285 4.551 1.972" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.888"/>
+<path d="m368.96 99.257 4.385 2.34" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.886"/>
+<path d="m373.34 101.6 4.956 1.546" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.847"/>
+<path d="m378.3 103.14 5.584 0.37" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.775"/>
+<path d="m383.88 103.51 6.206-0.775" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.661"/>
+<path d="m390.09 102.74 6.045-0.712" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.69"/>
+<path d="m396.13 102.03 5.047 1.039" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.854"/>
+<path d="m401.18 103.07 3.434 4.494" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.761"/>
+<path d="m404.61 107.56 2.365 8.269" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.265"/>
+<path d="m406.98 115.83 2.078 11.426" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.811"/>
+<path d="m409.06 127.26 2.62 13.031" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.579"/>
+<path d="m411.68 140.29 3.418 12.883" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.575"/>
+<path d="m415.1 153.17 4.202 10.6" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.842"/>
+<path d="m419.3 163.77 4.208 6.877" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.353"/>
+<path d="m423.5 170.65 3.253 2.46" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.049"/>
+<path d="m426.76 173.11 1.497-1.64" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.405"/>
+<path d="m428.26 171.46-0.139-5.288" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.824"/>
+<path d="m428.12 166.18-1.244-7.85" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.369"/>
+<path d="m426.87 158.33-1.52-9.083" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.168"/>
+<path d="m425.35 149.24-1.143-8.755" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.228"/>
+<path d="m424.21 140.49-0.264-7.579" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.429"/>
+<path d="m423.94 132.91 0.531-5.92" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.708"/>
+<path d="m424.48 126.99 0.915-4.423" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.964"/>
+<path d="m425.39 122.57 0.736-3.458" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.148"/>
+<path d="m426.13 119.11 0.354-3.718" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.11"/>
+<path d="m426.48 115.39-0.122-4.823" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.908"/>
+<path d="m426.36 110.57-0.563-6.162" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.665"/>
+<path d="m425.8 104.41-1.053-6.749" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.555"/>
+<path d="m424.74 97.657-1.469-6.352" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.608"/>
+<path d="m423.27 91.305-1.972-4.56" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.883"/>
+<path d="m421.3 86.746-2.517-1.725" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.243"/>
+<path d="m418.78 85.021-3.048 1.507" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.177"/>
+<path d="m415.74 86.528-3.144 3.762" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.896"/>
+<path d="m412.59 90.29-2.845 4.59" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.806"/>
+<path d="m409.75 94.88-2.269 3.824" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.978"/>
+<path d="m407.48 98.704-1.834 2.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.307"/>
+<path d="m405.64 100.71-1.561-0.51" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.522"/>
+<path d="m404.08 100.2-1.835-2.659" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.207"/>
+<path d="m402.25 97.543-2.686-3.834" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.936"/>
+<path d="m399.56 93.709-4.093-3.714" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.785"/>
+<path d="m395.47 89.995-5.304-2.97" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.689"/>
+<path d="m390.16 87.026-6.178-1.814" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.628"/>
+<path d="m383.99 85.212-6.536-0.708" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.606"/>
+<path d="M377.45 84.504l-6.613.204" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.599"/>
+<path d="m370.84 84.708-6.104 0.43" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.684"/>
+<path d="m364.73 85.139-5.514 0.337" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.788"/>
+<path d="M359.22 85.476l-5.094.138" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.864"/>
+<path d="m354.13 85.614-5.234 0.16" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.839"/>
+<path d="m348.89 85.774-5.335 0.066" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.822"/>
+<path d="m343.56 85.84-5.555 0.113" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.783"/>
+<path d="m338 85.953-5.756 0.293" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.746"/>
+<path d="m332.25 86.246-6.107 0.745" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.678"/>
+<path d="m326.14 86.991-5.906 1.107" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.703"/>
+<path d="m320.23 88.098-5.46 1.593" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.759"/>
+<path d="m314.77 89.69-4.85 2.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.819"/>
+<path d="m309.92 91.93-4.46 3.142" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.798"/>
+<path d="m305.46 95.072-3.7 3.968" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.802"/>
+<path d="m301.76 99.04-2.941 4.741" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.774"/>
+<path d="m298.82 103.78-2.228 5.352" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.735"/>
+<path d="m296.59 109.13-1.85 5.817" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.68"/>
+<path d="m294.74 114.95-1.18 5.847" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.704"/>
+<path d="m293.56 120.8-0.558 5.677" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.75"/>
+<path d="m293.01 126.47-0.034 5.45" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.795"/>
+<path d="m292.97 131.92 0.107 5.424" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.799"/>
+<path d="m293.08 137.35 0.448 5.375" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.805"/>
+<path d="m293.53 142.72 0.72 5.504" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.777"/>
+<path d="m294.25 148.23 0.978 5.704" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.735"/>
+<path d="m295.23 153.93 1.104 5.905" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.697"/>
+<path d="m296.33 159.84 1.709 5.587" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.726"/>
+<path d="m298.04 165.42 2.51 4.93" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.782"/>
+<path d="m300.55 170.36 3.422 4.053" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.824"/>
+<path d="m303.97 174.41 4.136 3.285" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.829"/>
+<path d="m308.11 177.69 4.985 2.44" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.782"/>
+<path d="m313.09 180.13 5.578 1.88" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.724"/>
+<path d="m318.67 182.01 5.854 1.56" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.694"/>
+<path d="m324.52 183.57 5.71 1.443" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.724"/>
+<path d="m330.23 185.02 5.678 0.945" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="M335.91 185.962l5.617.269" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.771"/>
+<path d="m341.53 186.23 5.588-0.417" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.774"/>
+<path d="m347.12 185.81 5.479-0.703" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.788"/>
+<path d="m352.59 185.11 5.653-0.776" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.756"/>
+<path d="m358.25 184.33 5.814-0.373" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.735"/>
+<path d="M364.06 183.961l5.898.264" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.722"/>
+<path d="m369.96 184.22 5.752 0.82" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.738"/>
+<path d="M375.71 185.046l5.73.527" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.748"/>
+<path d="m381.44 185.57 5.614-0.452" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.769"/>
+<path d="m387.05 185.12 5.362-1.814" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.763"/>
+<path d="m392.42 183.31 4.788-2.866" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.776"/>
+<path d="m397.2 180.44 4.226-3.34" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.81"/>
+<path d="m401.43 177.1 3.49-2.604" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.997"/>
+<path d="m404.92 174.5 2.597-0.72" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.314"/>
+<path d="m407.52 173.78 1.436 1.903" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.372"/>
+<path d="m408.95 175.68 0.445 4.159" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.026"/>
+<path d="m409.4 179.84-0.467 5.672" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.752"/>
+<path d="m408.93 185.51-1.279 6.177" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.645"/>
+<path d="m407.65 191.69-2.19 5.899" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.648"/>
+<path d="m405.46 197.59-2.855 4.892" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.759"/>
+<path d="m402.61 202.48-3.45 3.829" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.851"/>
+<path d="m399.16 206.31-4.025 2.966" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.88"/>
+<path d="m395.13 209.27-4.815 2.387" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.814"/>
+<path d="m390.32 211.66-5.417 1.593" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.766"/>
+<path d="m384.9 213.25-5.886 0.69" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.717"/>
+<path d="m379.01 213.94-6.148-0.23" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.678"/>
+<path d="m372.87 213.71-6.4-0.817" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.627"/>
+<path d="m366.47 212.9-6.21-1.077" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.652"/>
+<path d="m360.26 211.82-5.788-0.718" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.734"/>
+<path d="m354.47 211.1-5.313 0.067" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.826"/>
+<path d="m349.16 211.17-5.178 0.955" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.834"/>
+<path d="m343.98 212.12-5.155 1.042" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.835"/>
+<path d="m338.82 213.17-5.317 0.21" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.824"/>
+<path d="m333.51 213.38-5.479-1.384" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.765"/>
+<path d="m328.03 211.99-5.425-2.91" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.676"/>
+<path d="m322.6 209.08-4.946-4.249" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.612"/>
+<path d="m317.66 204.83-4.172-4.698" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.652"/>
+<path d="m313.48 200.14-3.33-4.085" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.829"/>
+<path d="m310.15 196.05-2.728-2.34" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.139"/>
+<path d="m307.42 193.71-2.37-0.456" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.369"/>
+<path d="m305.06 193.25-2.295 1.271" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.327"/>
+<path d="m302.76 194.52-2.218 2.578" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.175"/>
+<path d="m300.54 197.1-1.818 3.747" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.03"/>
+<path d="m298.72 200.85-0.615 4.363" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.984"/>
+<path d="m298.11 205.21 1.238 4.712" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.899"/>
+<path d="m299.35 209.92 3.41 4.803" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.719"/>
+<path d="m302.76 214.73 5.333 4.795" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.502"/>
+<path d="m308.09 219.52 6.694 4.116" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.39"/>
+<path d="m314.78 223.64 7.028 2.915" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.432"/>
+<path d="m321.81 226.55 6.408 1.378" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.609"/>
+<path d="M328.22 227.932l5.204.06" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.845"/>
+<path d="m333.42 227.99 4.297-1.017" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.988"/>
+<path d="m337.72 226.98 4.002-1.4" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.02"/>
+<path d="m341.72 225.58 4.526-1.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.947"/>
+<path d="m346.25 224.56 5.619 0.12" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.771"/>
+<path d="m351.87 224.68 7.018 1.16" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.515"/>
+<path d="m358.88 225.84 7.82 1.727" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.367"/>
+<path d="m366.7 227.57 7.529 1.432" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.423"/>
+<path d="m374.23 229 6.07 0.37" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.69"/>
+<path d="m380.3 229.38 4.294-1.335" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.973"/>
+<path d="m384.6 228.04 2.895-2.83" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.053"/>
+<path d="m387.5 225.21 2.764-3.344" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.999"/>
+<path d="m390.26 221.87 4.214-2.401" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.907"/>
+<path d="m394.47 219.46 6.982-0.591" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.533"/>
+<path d="m401.46 218.87 9.389 1.002" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.142"/>
+<path d="m410.84 219.88 9.462 0.784" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.133"/>
+<path d="m420.31 220.66 5.483-2.467" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.701"/>
+<path d="m425.79 218.19-2.79-9.26" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.098"/>
+<path d="m423 208.93-14.408-18.35" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.484"/>
+<path d="m408.59 190.58-26.71-27.276" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".551"/>
+<path d="m381.88 163.31-36.317-32.953" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".219"/>
+<path d="m345.56 130.36-40.007-33.391" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".162"/>
+<path d="m305.56 96.964-36.492-27.957" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".292"/>
+<path d="m269.06 69.007-26.535-18.164" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".851"/>
+<path d="m242.53 50.843-12.946-6.917" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.408"/>
+<path d="m229.58 43.926 0.625 2.062" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.417"/>
+<path d="m230.21 45.988 10.461 6.482" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.721"/>
+<path d="m240.67 52.47 14.398 5.932" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.299"/>
+<path d="m255.07 58.402 12.293 2.231" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.698"/>
+<path d="m267.36 60.633 6.076-2.182" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.625"/>
+<path d="m273.44 58.451-1.462-4.462" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.932"/>
+<path d="m271.97 53.989-7.469-3.146" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.351"/>
+<path d="m264.5 50.843-10.137 1.683" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.015"/>
+<path d="m254.37 52.526-8.996 7.8" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.775"/>
+<path d="m245.37 60.326-5.196 13.001" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.487"/>
+<path d="m240.18 73.327-0.632 15.483" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.297"/>
+<path d="m239.54 88.81 2.838 14.9" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.338"/>
+<path d="m242.38 103.71 4.08 11.633" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.711"/>
+<path d="m246.46 115.34 2.984 7.373" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.369"/>
+<path d="m249.45 122.72 0.498 3.774" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.096"/>
+<path d="m249.94 126.49-1.766 2.033" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.312"/>
+<path d="m248.18 128.52-2.828 2.158" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.146"/>
+<path d="m245.35 130.68-2.305 3.642" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.004"/>
+<path d="m243.04 134.32-0.632 5.543" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.772"/>
+<path d="m242.41 139.87 1.35 7.085" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.491"/>
+<path d="m243.76 146.95 2.464 7.616" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.361"/>
+<path d="m246.23 154.57 2.099 7.196" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.444"/>
+<path d="m248.33 161.76 0.52 6.196" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.66"/>
+<path d="m248.85 167.96-1.217 5.194" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.816"/>
+<path d="m247.63 173.15-2.014 4.392" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.907"/>
+<path d="m245.62 177.54-1.324 3.92" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.035"/>
+<path d="m244.29 181.47 0.74 3.562" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.128"/>
+<path d="m245.03 185.03 3.408 3.027" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.959"/>
+<path d="m248.44 188.06 5.525 1.805" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.737"/>
+<path d="m253.96 189.86 5.969-0.126" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.71"/>
+<path d="m259.93 189.73 4.514-2.505" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.851"/>
+<path d="m264.45 187.23 1.832-4.713" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.866"/>
+<path d="m266.28 182.52-0.731-6.367" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.627"/>
+<path d="m265.55 176.15-2.267-7.064" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.457"/>
+<path d="m263.28 169.08-2.224-6.848" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.493"/>
+<path d="m261.06 162.24-0.827-5.988" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.69"/>
+<path d="m260.23 156.25 1.148-5.305" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.799"/>
+<path d="m261.38 150.94 2.415-5.034" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.773"/>
+<path d="m263.8 145.91 2.232-5.22" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.755"/>
+<path d="m266.03 140.69 0.7-5.416" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.793"/>
+<path d="m266.73 135.27-1.45-5.788" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.704"/>
+<path d="m265.28 129.49-2.983-5.82" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.606"/>
+<path d="m262.3 123.67-2.914-5.615" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.643"/>
+<path d="m259.38 118.05-0.974-5.297" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.807"/>
+<path d="m258.41 112.75 1.957-5.683" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.697"/>
+<path d="m260.36 107.07 4.253-6.285" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.431"/>
+<path d="m264.62 100.78 4.029-6.406" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.434"/>
+<path d="m268.65 94.379 2e-3 -4.86" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.901"/>
+<path d="m268.65 89.519-8.02-1.563" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.341"/>
+<path d="m260.63 87.956-18.637 3.802" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.908"/>
+<path d="m241.99 91.758-29.203 10.295" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".925"/>
+<path d="m212.79 102.05-36.521 16.48" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".479"/>
+<path d="m176.27 118.53-38.3 20.038" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".371"/>
+<path d="m137.97 138.57-33.586 20.129" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".514"/>
+<path d="m104.38 158.7-23.412 16.78" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.062"/>
+<path d="m80.97 175.48-10.32 11.369" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.32"/>
+<path d="m70.65 186.85 2.107 5.226" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.763"/>
+<path d="M72.757 192.075l10.977.34" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.912"/>
+<path d="m83.734 192.42 14.782-2.22" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.377"/>
+<path d="m98.516 190.2 13.97-2.194" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.479"/>
+<path d="m112.49 188 10.011-0.847" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.05"/>
+<path d="m122.5 187.15 5.321 0.846" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.812"/>
+<path d="m127.82 188 1.94 1.908" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.307"/>
+<path d="m129.76 189.91 1.09 2.11" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.374"/>
+<path d="m130.85 192.02 2.327 1.221" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.326"/>
+<path d="m133.17 193.24 4.682-0.022" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.939"/>
+<path d="m137.86 193.22 6.886-0.994" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.541"/>
+<path d="m144.74 192.22 8.208-1.116" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.323"/>
+<path d="m152.95 191.11 8.048-0.804" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.355"/>
+<path d="m161 190.3 6.83-0.213" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.562"/>
+<path d="m167.83 190.09 5.285 0.276" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.829"/>
+<path d="m173.11 190.37 4.316 0.614" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.998"/>
+<path d="M177.429 190.98l4.076.27" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.049"/>
+<path d="m181.5 191.25 4.55-0.514" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.958"/>
+<path d="m186.06 190.74 5.336-1.517" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.784"/>
+<path d="m191.39 189.22 6.037-2.272" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.626"/>
+<path d="m197.43 186.95 6.016-3.106" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.571"/>
+<path d="m203.44 183.84 5.145-3.788" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.635"/>
+<path d="m208.59 180.05 3.603-4.345" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.763"/>
+<path d="m212.19 175.71 1.924-4.58" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.883"/>
+<path d="m214.12 171.13 0.42-5.054" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.863"/>
+<path d="m214.54 166.08-0.605-5.524" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.776"/>
+<path d="m213.93 160.55-1.14-5.874" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.701"/>
+<path d="m212.79 154.68-1.352-5.69" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.725"/>
+<path d="m211.44 148.99-1.716-5.395" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.758"/>
+<path d="m209.72 143.59-2.489-4.69" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.821"/>
+<path d="m207.23 138.9-3.688-3.648" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.845"/>
+<path d="m203.54 135.25-4.994-2.207" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.798"/>
+<path d="m198.55 133.05-6.074-1.19" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.671"/>
+<path d="m192.48 131.86-6.605-0.513" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.597"/>
+<path d="m185.87 131.34-6.497-0.222" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.618"/>
+<path d="m179.37 131.12-5.873 0.026" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.727"/>
+<path d="m173.5 131.15-5.264-0.175" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.834"/>
+<path d="m168.24 130.97-4.955-0.355" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.887"/>
+<path d="m163.28 130.62-5.095-0.374" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.862"/>
+<path d="m158.19 130.24-5.405 0.025" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.809"/>
+<path d="m152.78 130.26-6.021 0.254" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.7"/>
+<path d="m146.76 130.52-6.364 0.343" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.64"/>
+<path d="m140.4 130.86-6.286 0.22" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.655"/>
+<path d="m134.11 131.08-5.705 0.131" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.756"/>
+<path d="m128.4 131.21-5.314-0.331" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.824"/>
+<path d="m123.09 130.88-5.026-0.973" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.86"/>
+<path d="m118.06 129.91-4.814-1.755" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.859"/>
+<path d="m113.25 128.16-4.272-2.406" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.898"/>
+<path d="m108.98 125.75-3.57-3.332" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.9"/>
+<path d="m105.41 122.42-2.29-4.259" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.907"/>
+<path d="m103.12 118.16-0.441-4.968" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.878"/>
+<path d="m102.68 113.19 1.929-4.96" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.819"/>
+<path d="m104.61 108.23 3.932-4.514" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.703"/>
+<path d="m108.54 103.72 5.38-3.486" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.631"/>
+<path d="m113.92 100.23 6.092-2.081" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.628"/>
+<path d="m120.01 98.149 6.365-0.407" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.639"/>
+<path d="m126.38 97.742 6 0.705" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.697"/>
+<path d="m132.38 98.447 5.512 1.142" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.769"/>
+<path d="M137.888 99.59l5.198.893" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.832"/>
+<path d="m143.09 100.48 5.43 0.421" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.802"/>
+<path d="m148.52 100.9 5.692-0.316" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.757"/>
+<path d="m154.21 100.59 5.946-0.803" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.705"/>
+<path d="m160.16 99.785 6.004-0.794" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.695"/>
+<path d="M166.16 98.99l6.003-.056" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.704"/>
+<path d="M172.163 98.934l5.542.861" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.773"/>
+<path d="m177.7 99.795 4.868 1.856" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.843"/>
+<path d="m182.57 101.65 4.177 2.679" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.887"/>
+<path d="m186.75 104.33 3.874 3.332" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.859"/>
+<path d="m190.62 107.66 3.654 3.307" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.892"/>
+<path d="m194.28 110.97 3.578 2.746" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.968"/>
+<path d="m197.86 113.72 3.493 1.676" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.087"/>
+<path d="M201.35 115.39l3.394.366" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.175"/>
+<path d="m204.74 115.76 2.753-1.457" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.232"/>
+<path d="m207.5 114.3 1.616-3.313" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.12"/>
+<path d="m209.11 110.99 0.056-4.84" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.905"/>
+<path d="m209.17 106.15-1.539-5.495" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.75"/>
+<path d="m207.63 100.65-3.248-5.511" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.631"/>
+<path d="m204.38 95.142-4.668-4.688" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.595"/>
+<path d="m199.72 90.454-5.627-3.27" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.615"/>
+<path d="m194.09 87.183-5.933-1.489" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.684"/>
+<path d="m188.16 85.694-6.025-0.238" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.7"/>
+<path d="M182.13 85.456l-5.894.411" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.721"/>
+<path d="m176.24 85.867-5.704 0.436" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.754"/>
+<path d="m170.53 86.303-5.43 0.243" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.804"/>
+<path d="m165.1 86.546-5.465-0.27" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.797"/>
+<path d="m159.64 86.275-5.578-0.591" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.773"/>
+<path d="m154.06 85.684-5.695-0.567" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.753"/>
+<path d="m148.36 85.117-5.624-0.084" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="m142.74 85.033-5.725 0.268" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.752"/>
+<path d="m137.01 85.3-5.773 0.506" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.74"/>
+<path d="m131.24 85.806-5.779 0.555" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.739"/>
+<path d="m125.46 86.36-5.589 0.642" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="m119.87 87.002-5.638 0.531" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.764"/>
+<path d="m114.24 87.533-5.631 0.654" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.762"/>
+<path d="m108.6 88.187-5.484 1.14" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.774"/>
+<path d="m103.12 89.327-4.936 2.145" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.812"/>
+<path d="m98.184 91.472-4.41 3.091" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.811"/>
+<path d="m93.773 94.563-3.679 4.041" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.795"/>
+<path d="m90.094 98.604-2.768 4.845" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.773"/>
+<path d="m87.326 103.45-1.539 5.574" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.736"/>
+<path d="m85.787 109.02-0.53 5.772" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.734"/>
+<path d="m85.258 114.8 0.403 5.724" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.744"/>
+<path d="m85.66 120.52 1.261 5.491" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.763"/>
+<path d="m86.921 126.01 2.296 5.269" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.743"/>
+<path d="m89.217 131.28 3.079 4.605" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.781"/>
+<path d="m92.296 135.88 3.8 3.759" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.817"/>
+<path d="m96.096 139.64 4.462 2.786" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.833"/>
+<path d="m100.56 142.43 5.266 1.965" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="m105.82 144.4 5.714 0.947" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.741"/>
+<path d="m111.54 145.34 5.92 0.12" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.718"/>
+<path d="m117.46 145.46 5.906-0.39" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.719"/>
+<path d="m123.36 145.07 5.983-0.358" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.706"/>
+<path d="m129.35 144.71 5.805-0.291" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.737"/>
+<path d="m135.15 144.42 5.594-0.08" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.776"/>
+<path d="m140.74 144.34 5.423 0.136" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.806"/>
+<path d="m146.17 144.48 5.585 0.425" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.775"/>
+<path d="m151.75 144.9 5.643 0.266" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.766"/>
+<path d="m157.4 145.17 5.69-0.024" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.759"/>
+<path d="m163.09 145.15 5.694-0.266" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.757"/>
+<path d="M168.78 144.88l5.866-.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.728"/>
+<path d="M174.646 144.83l5.712.28" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.754"/>
+<path d="m180.36 145.11 5.311 1.053" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.807"/>
+<path d="m185.67 146.16 4.605 2.18" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.863"/>
+<path d="m190.28 148.34 3.8 3.627" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.833"/>
+<path d="m194.08 151.97 2.429 4.587" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.843"/>
+<path d="m196.5 156.56 0.736 5.084" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.851"/>
+<path d="m197.24 161.64-1.13 5.016" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.851"/>
+<path d="m196.11 166.66-2.71 4.614" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.814"/>
+<path d="m193.4 171.27-4.298 3.535" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.778"/>
+<path d="m189.1 174.8-5.508 2.29" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.71"/>
+<path d="m183.59 177.1-6.224 1.12" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.648"/>
+<path d="m177.37 178.22-6.184 0.394" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.671"/>
+<path d="m171.19 178.61-6.052-0.315" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.694"/>
+<path d="m165.13 178.3-5.774-0.7" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.737"/>
+<path d="m159.36 177.6-5.527-0.757" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.778"/>
+<path d="m153.83 176.84-5.182-0.337" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.847"/>
+<path d="m148.65 176.5-5.37-0.025" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.816"/>
+<path d="m143.28 176.48-5.731 0.303" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.75"/>
+<path d="M137.55 176.78l-6.079.479" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.688"/>
+<path d="m131.47 177.26-5.954 0.491" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.709"/>
+<path d="m125.52 177.75-5.813-0.187" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.737"/>
+<path d="m119.7 177.56-5.342-1.257" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.794"/>
+<path d="m114.36 176.3-4.636-2.49" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.833"/>
+<path d="m109.73 173.81-3.66-3.42" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.877"/>
+<path d="m106.06 170.39-3.15-4.13" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.843"/>
+<path d="m102.92 166.26-2.912-4.216" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.855"/>
+<path d="m100 162.05-2.893-3.659" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.939"/>
+<path d="m97.11 158.39-2.757-2.488" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.116"/>
+<path d="m94.353 155.9-2.799-1.36" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.232"/>
+<path d="m91.554 154.54-2.625-0.38" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.322"/>
+<path d="m88.93 154.16-2.201 0.266" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.408"/>
+<path d="M86.729 154.43l-1.463.675" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.528"/>
+<path d="m85.266 155.1-0.928 0.57" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.635"/>
+<path d="M84.338 155.675l-.485.28" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.745"/>
+<path d="m83.853 155.95-0.129-0.032" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.835"/>
+<path d="M83.724 155.922l.337-.092" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.789"/>
+<path d="M84.06 155.83l.705-.242" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.706"/>
+<path d="m84.765 155.59 1.224-0.284" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.601"/>
+<path d="m85.989 155.3 1.876-0.205" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.473"/>
+<path d="m87.865 155.1 2.655 0.185" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.32"/>
+<path d="M90.52 155.284l3.06.442" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.237"/>
+<path d="M93.58 155.726l3.072.703" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.225"/>
+<path d="M96.652 156.429l2.654.89" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.293"/>
+<path d="m99.306 157.32 2.049 1.088" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.386"/>
+<path d="m101.36 158.41 1.136 0.81" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.572"/>
+<path d="M102.49 159.216l.262.242" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.788"/>
+<path d="m102.75 159.46-0.383-0.494" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.731"/>
+<path d="m102.37 158.96-0.54-1.016" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.621"/>
+<path d="m101.83 157.95-0.579-1.466" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.534"/>
+<path d="m101.25 156.48-0.474-1.478" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.539"/>
+<path d="m100.78 155-0.315-0.939" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.654"/>
+<path d="M100.462 154.065l.08.286" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.8"/>
+<path d="m100.54 154.35 0.312 1.642" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.515"/>
+<path d="m100.85 155.99 0.62 2.974" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.244"/>
+<path d="m101.47 158.97 1.106 3.979" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.036"/>
+<path d="m102.58 162.94 2.094 4.6" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.867"/>
+<path d="m104.67 167.55 3.047 4.366" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.82"/>
+<path d="m107.72 171.91 4.067 3.496" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.814"/>
+<path d="m111.79 175.41 5.008 2.234" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.794"/>
+<path d="m116.8 177.64 6.001 1.109" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.687"/>
+<path d="m122.8 178.75 6.367 0.014" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.641"/>
+<path d="m129.16 178.76 6.328-0.692" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.641"/>
+<path d="m135.49 178.07 5.996-0.928" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.693"/>
+<path d="m141.49 177.14 5.83-0.527" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.73"/>
+<path d="m147.32 176.62 5.424-0.134" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.806"/>
+<path d="M152.74 176.483l5.197.212" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.845"/>
+<path d="m157.94 176.7 5.218 0.353" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.84"/>
+<path d="m163.16 177.05 5.688 0.476" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.756"/>
+<path d="m168.84 177.52 5.868 0.055" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.728"/>
+<path d="m174.71 177.58 5.852-0.672" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.724"/>
+<path d="m180.56 176.91 5.493-1.62" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.752"/>
+<path d="m186.06 175.29 4.95-2.421" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.789"/>
+<path d="m191.01 172.87 3.676-3.476" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.868"/>
+<path d="m194.68 169.39 2.069-4.422" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.898"/>
+<path d="m196.75 164.97 0.303-5.066" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.862"/>
+<path d="m197.05 159.9-1.239-4.962" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.856"/>
+<path d="m195.82 154.94-2.916-4.542" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.806"/>
+<path d="m192.9 150.4-4.32-3.648" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.762"/>
+<path d="m188.58 146.75-5.353-2.444" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.724"/>
+<path d="m183.22 144.31-5.814-0.931" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.724"/>
+<path d="m177.41 143.38-6.183 0.091" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.673"/>
+<path d="m171.23 143.47-6.247 0.631" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.656"/>
+<path d="m164.98 144.1-6.081 0.668" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.684"/>
+<path d="m158.9 144.76-5.663 0.592" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.758"/>
+<path d="m153.24 145.36-5.495 0.132" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.793"/>
+<path d="m147.74 145.49-5.41-0.286" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.807"/>
+<path d="m142.33 145.2-5.427-0.495" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.801"/>
+<path d="m136.9 144.71-5.406-0.24" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.808"/>
+<path d="m131.5 144.47-5.666-0.077" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.763"/>
+<path d="m125.83 144.39-5.885 0.013" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.725"/>
+<path d="m119.94 144.4-5.962-0.118" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.711"/>
+<path d="m113.98 144.29-5.687-0.33" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.758"/>
+<path d="m108.3 143.96-5.438-1.083" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.784"/>
+<path d="m102.86 142.87-4.976-2.096" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.809"/>
+<path d="m97.882 140.78-4.316-3.208" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.812"/>
+<path d="m93.566 137.57-3.335-4.018" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.838"/>
+<path d="m90.23 133.55-2.525-4.876" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.789"/>
+<path d="m87.705 128.68-1.67-5.517" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.74"/>
+<path d="m86.034 123.16-0.769-5.894" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.708"/>
+<path d="m85.265 117.27 0.36-5.753" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.739"/>
+<path d="m85.625 111.51 1.25-5.556" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.752"/>
+<path d="m86.876 105.96 2.131-5.162" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.772"/>
+<path d="m89.007 100.8 3-4.58" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.793"/>
+<path d="m92.006 96.216 4.036-3.602" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.806"/>
+<path d="m96.042 92.614 4.738-2.736" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.796"/>
+<path d="m100.78 89.878 5.266-1.91" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.774"/>
+<path d="m106.05 87.969 5.606-1.207" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.751"/>
+<path d="m111.65 86.762 5.987-0.467" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.704"/>
+<path d="M117.64 86.295l5.976-.172" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.708"/>
+<path d="m123.62 86.123 5.816-0.126" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.737"/>
+<path d="m129.43 85.997 5.603-0.23" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.773"/>
+<path d="m135.04 85.767 5.655-0.142" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.765"/>
+<path d="M140.69 85.625l5.593-.173" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.775"/>
+<path d="m146.28 85.452 5.575-0.121" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.779"/>
+<path d="m151.86 85.33 5.577-3e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.779"/>
+<path d="M157.435 85.327l5.768.315" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.744"/>
+<path d="m163.2 85.642 5.748 0.357" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="M168.95 85.999l5.652.302" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.764"/>
+<path d="m174.6 86.301 5.522 0.251" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.787"/>
+<path d="M180.124 86.552l5.58.57" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.773"/>
+<path d="m185.7 87.123 5.472 0.964" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.782"/>
+<path d="m191.18 88.087 5.265 1.704" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.786"/>
+<path d="m196.44 89.79 4.83 2.733" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.782"/>
+<path d="m201.27 92.523 4.198 4.046" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.731"/>
+<path d="m205.47 96.57 2.953 4.89" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.75"/>
+<path d="m208.42 101.46 1.332 5.159" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.817"/>
+<path d="m209.76 106.62-0.45 4.676" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.931"/>
+<path d="m209.3 111.3-1.97 3.65" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.034"/>
+<path d="m207.33 114.94-3.297 1.824" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.107"/>
+<path d="m204.04 116.77-4.075-0.253" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.049"/>
+<path d="m199.96 116.52-4.314-2.16" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.912"/>
+<path d="m195.65 114.36-4.07-3.33" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.833"/>
+<path d="m191.58 111.03-3.962-3.966" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.77"/>
+<path d="m187.62 107.06-4.003-3.824" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.783"/>
+<path d="m183.61 103.24-4.298-3.04" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.832"/>
+<path d="m179.32 100.2-4.686-1.71" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.883"/>
+<path d="m174.63 98.486-5.393-0.559" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.806"/>
+<path d="m169.24 97.927-5.965 0.33" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.709"/>
+<path d="M163.27 98.257l-6.24.791" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.654"/>
+<path d="M157.03 99.048l-6.052.952" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.683"/>
+<path d="m150.98 100-5.908 0.538" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.716"/>
+<path d="m145.07 100.54-5.695-9e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.758"/>
+<path d="m139.38 100.53-5.534-0.43" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.783"/>
+<path d="m133.84 100.1-5.324-0.36" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.821"/>
+<path d="m128.52 99.74-5.46-0.101" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.799"/>
+<path d="m123.06 99.639-5.522 0.606" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.783"/>
+<path d="m117.53 100.24-5.284 1.674" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.784"/>
+<path d="m112.25 101.92-4.39 3.057" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.817"/>
+<path d="m107.86 104.98-3.226 4.084" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.841"/>
+<path d="m104.63 109.06-1.626 4.79" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.866"/>
+<path d="m103.01 113.85 0.246 5.023" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.87"/>
+<path d="m103.25 118.87 2.336 4.876" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.804"/>
+<path d="m105.59 123.75 3.925 3.956" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.776"/>
+<path d="m109.52 127.7 5.055 2.708" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.749"/>
+<path d="m114.57 130.41 5.692 1.397" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.729"/>
+<path d="M120.262 131.81l6.134.437" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.679"/>
+<path d="m126.4 132.25 6.071-0.412" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.69"/>
+<path d="m132.47 131.84 5.855-0.797" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.72"/>
+<path d="m138.32 131.04 5.63-0.74" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.761"/>
+<path d="m143.95 130.3 5.715-0.235" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.754"/>
+<path d="m149.67 130.06 5.652 0.072" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.766"/>
+<path d="m155.32 130.14 5.578 0.283" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.777"/>
+<path d="m160.9 130.42 5.494 0.34" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.792"/>
+<path d="m166.39 130.76 5.666 0.456" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.76"/>
+<path d="m172.06 131.21 5.669 0.264" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.761"/>
+<path d="m177.73 131.48 5.64 0.184" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.767"/>
+<path d="M183.366 131.66l5.56.36" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.78"/>
+<path d="m188.93 132.02 5.62 1.045" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.754"/>
+<path d="m194.55 133.06 5.326 1.762" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.772"/>
+<path d="m199.87 134.83 4.751 2.656" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.801"/>
+<path d="m204.62 137.48 3.91 3.608" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.821"/>
+<path d="m208.53 141.09 3.132 4.66" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.768"/>
+<path d="m211.67 145.75 2.073 5.274" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.757"/>
+<path d="m213.74 151.02 0.973 5.631" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.748"/>
+<path d="m214.71 156.66-0.093 5.735" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.744"/>
+<path d="m214.62 162.39-0.842 5.788" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.724"/>
+<path d="m213.78 168.18-1.765 5.374" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.759"/>
+<path d="m212.01 173.55-2.707 4.784" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.788"/>
+<path d="m209.31 178.34-3.642 4.07" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.796"/>
+<path d="m205.66 182.41-4.244 3.45" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.795"/>
+<path d="m201.42 185.86-4.959 2.525" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.78"/>
+<path d="m196.46 188.38-5.52 1.626" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="m190.94 190.01-5.885 0.857" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.714"/>
+<path d="m185.06 190.86-5.779 0.465" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.74"/>
+<path d="m179.28 191.33-5.808 0.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.738"/>
+<path d="m173.47 191.38-5.798-0.139" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.74"/>
+<path d="m167.67 191.24-5.786-0.146" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.742"/>
+<path d="m161.88 191.1-5.506 0.109" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.791"/>
+<path d="m156.38 191.2-5.559 0.11" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.782"/>
+<path d="m150.82 191.32-5.657 0.06" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.765"/>
+<path d="m145.16 191.37-5.756-0.03" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.747"/>
+<path d="m139.41 191.34-5.545 0.027" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.785"/>
+<path d="m133.86 191.37-5.63-0.131" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.769"/>
+<path d="m128.23 191.24-5.724-0.275" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.752"/>
+<path d="m122.51 190.96-5.792-0.424" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.738"/>
+<path d="m116.72 190.54-5.525-0.517" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.784"/>
+<path d="m111.19 190.02-5.455-1.007" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.784"/>
+<path d="m105.74 189.02-5.271-1.74" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.783"/>
+<path d="m100.47 187.28-4.898-2.67" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.777"/>
+<path d="m95.57 184.61-4.039-3.513" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.816"/>
+<path d="m91.531 181.09-3.237-4.416" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.793"/>
+<path d="m88.294 176.68-2.346-4.928" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.795"/>
+<path d="m85.948 171.75-1.453-4.844" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.866"/>
+<path d="m84.495 166.91-0.421-3.945" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.066"/>
+<path d="m84.074 162.96 0.17-2.685" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.311"/>
+<path d="m84.244 160.28 0.456-1.104" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.612"/>
+<path d="M84.7 159.172l.469.481" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.721"/>
+<path d="m85.169 159.65 0.524 1.874" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.459"/>
+<path d="m85.693 161.53 0.3 2.484" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.348"/>
+<path d="m85.994 164.01 0.045 2.44" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.36"/>
+<path d="m86.04 166.45-0.159 1.871" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.473"/>
+<path d="m85.881 168.32-0.06 1.163" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.618"/>
+<path d="M85.821 169.485l-.054.286" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.801"/>
+<path d="M85.767 169.77l-.057-.314" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.795"/>
+<path d="m85.71 169.46-0.08-0.483" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.759"/>
+<path d="M85.63 168.973l.1-.11" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.832"/>
+<path d="M85.73 168.863l.13.373" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.779"/>
+<path d="M85.86 169.236l.153.92" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.666"/>
+<path d="m86.013 170.16 0.196 1.362" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.575"/>
+<path d="m86.209 171.52 0.484 1.697" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.496"/>
+<path d="m86.693 173.22 0.62 1.651" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.496"/>
+<path d="m87.314 174.87 0.682 1.4" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.538"/>
+<path d="m87.996 176.27 0.64 1.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.605"/>
+<path d="M88.636 177.316l.697.804" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.639"/>
+<path d="M89.333 178.12l.475.498" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.718"/>
+<path d="M89.808 178.618l.179.274" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.794"/>
+<path d="M89.987 178.892l-.1.147" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.825"/>
+<path d="M89.888 179.039l-.043.22" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.815"/>
+<path d="M89.845 179.259l-.044.25" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.809"/>
+<path d="M89.8 179.508l.09.333" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.79"/>
+<path d="M89.89 179.84l.325.462" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.744"/>
+<path d="M90.215 180.302l.827.721" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.633"/>
+<path d="M91.042 181.023l1.025.848" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.585"/>
+<path d="M92.067 181.871l1.076.911" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.569"/>
+<path d="M93.143 182.782l.982.888" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.586"/>
+<path d="M94.125 183.67l1.014.875" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.583"/>
+<path d="M95.139 184.545l.721.654" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.658"/>
+<path d="M95.86 185.199l.424.379" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.743"/>
+<path d="M96.284 185.578l.19.12" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.815"/>
+<path d="M96.475 185.698l.294.053" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.8"/>
+<path d="M96.769 185.751l.19-.021" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.822"/>
+<path d="M96.96 185.73l.164.02" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.828"/>
+<path d="M97.124 185.75l.237.159" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.803"/>
+<path d="M97.36 185.909l.658.45" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.695"/>
+<path d="M98.018 186.359l.842.553" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.651"/>
+<path d="M98.86 186.912l1.052.573" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.612"/>
+<path d="M99.912 187.485l1.243.51" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.583"/>
+<path d="m101.16 187.99 1.576 0.516" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.519"/>
+<path d="M102.731 188.51l1.433.344" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.557"/>
+<path d="m104.16 188.85 1.098 0.198" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.63"/>
+<path d="M105.262 189.052l.65.11" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.724"/>
+<path d="M105.912 189.162l.431.19" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.764"/>
+<path d="M106.343 189.352l.03.135" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.834"/>
+<path d="m106.37 189.49-0.162 0.07" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.826"/>
+<path d="m106.21 189.56-0.086 7e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.845"/>
+<path d="M106.124 189.564l.419.085" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.773"/>
+<path d="M106.543 189.65l.765.058" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.702"/>
+<path d="m107.31 189.71 1.122 0.084" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.628"/>
+<path d="M108.43 189.792l1.412.154" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.567"/>
+<path d="m109.84 189.95 1.761 0.35" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.491"/>
+<path d="m111.6 190.3 1.66 0.351" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.511"/>
+<path d="m113.26 190.65 1.41 0.274" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.564"/>
+<path d="M114.674 190.92l1.08.136" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.635"/>
+<path d="M115.755 191.056l.922.097" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.669"/>
+<path d="m116.68 191.15 0.511-0.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.755"/>
+<path d="m117.19 191.1 0.179-0.13" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.816"/>
+<path d="m117.37 190.97-0.014-0.127" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.836"/>
+<path d="M117.353 190.846l.143.046" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.831"/>
+<path d="m117.5 190.89 0.193 0.09" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.818"/>
+<path d="M117.689 190.982l.403.094" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.776"/>
+<path d="M118.092 191.076l.764.057" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.702"/>
+<path d="m118.86 191.13 1.388 0.111" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.573"/>
+<path d="m120.24 191.24 1.723 0.038" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.506"/>
+<path d="m121.97 191.28 1.93-7e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.465"/>
+<path d="m123.9 191.28 1.932-8e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.464"/>
+<path d="m125.83 191.27 1.857 0.128" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.478"/>
+<path d="m127.68 191.4 1.29 0.12" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.593"/>
+<path d="M128.975 191.515l.62.066" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.732"/>
+<path d="m129.6 191.58 0.047-0.026" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.852"/>
+<path d="m129.64 191.55-0.092-0.019" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.843"/>
+<path d="m129.55 191.54-0.144-0.114" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.824"/>
+<path d="m129.41 191.42 0.108-0.162" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.822"/>
+<path d="m129.51 191.26 0.532-0.145" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.747"/>
+<path d="m130.05 191.11 1.089 0.034" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.635"/>
+<path d="m131.14 191.15 1.21 0.091" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.61"/>
+<path d="M132.346 191.24l1.154.112" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.621"/>
+<path d="M133.5 191.352l1.092.087" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.634"/>
+<path d="m134.59 191.44 1.412 0.137" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.568"/>
+<path d="m136 191.58 1.893 0.046" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.472"/>
+<path d="m137.9 191.62 2.81-0.038" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.291"/>
+<path d="m140.71 191.58 3.997-0.088" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.065"/>
+<path d="m144.7 191.5 5.237 0.017" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.839"/>
+<path d="m149.94 191.51 5.732 0.02" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.751"/>
+<path d="m155.67 191.53 5.453 0.012" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.801"/>
+<path d="m161.13 191.54 4.398-0.01" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.991"/>
+<path d="m165.52 191.54 2.96 0.066" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.262"/>
+<path d="m168.48 191.6 1.177 5e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.617"/>
+<path d="m169.66 191.61-0.256-0.065" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.807"/>
+<path d="m169.4 191.54-1.01-0.12" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.65"/>
+<path d="m168.39 191.42-0.867-0.036" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.681"/>
+<path d="m167.53 191.38-0.364-0.055" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.785"/>
+<path d="M167.163 191.33l.428-.068" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.772"/>
+<path d="m167.59 191.26 1.209-0.072" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.61"/>
+<path d="m168.8 191.19 1.87 0.043" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.476"/>
+<path d="M170.67 191.233l1.96.03" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.459"/>
+<path d="m172.63 191.26h1.742" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.502"/>
+<path d="m174.37 191.26 1.36-0.034" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.579"/>
+<path d="m175.73 191.23 1.084 0.05" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.636"/>
+<path d="m176.82 191.28 0.667 8e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.723"/>
+<path d="m177.48 191.29 0.38-0.043" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.782"/>
+<path d="m177.86 191.24 0.239-0.091" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.809"/>
+<path d="m178.1 191.15 0.34-7e-3" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.791"/>
+<path d="m178.44 191.14 0.308-0.043" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.797"/>
+<path d="m178.75 191.1 0.345-0.082" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.788"/>
+<path d="m179.1 191.02 0.47-0.117" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.761"/>
+<path d="m179.57 190.9 0.802-0.02" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.694"/>
+<path d="m180.37 190.88 0.998-0.047" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.654"/>
+<path d="m181.36 190.84 1.218-0.087" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.608"/>
+<path d="m182.58 190.75 1.413-0.134" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.568"/>
+<path d="m184 190.62 1.617-0.054" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.527"/>
+<path d="m185.61 190.56 1.46-0.11" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.559"/>
+<path d="m187.07 190.45 1.135-0.172" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.623"/>
+<path d="M188.208 190.28l.718-.219" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.705"/>
+<path d="m188.93 190.06 0.43-0.103" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.77"/>
+<path d="m189.36 189.96 0.077-0.09" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.838"/>
+<path d="m189.43 189.87-0.056-0.076" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.843"/>
+<path d="m189.38 189.79 0.068-0.074" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.842"/>
+<path d="M189.446 189.717l.498.024" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.758"/>
+<path d="m189.94 189.74 0.816-0.065" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.691"/>
+<path d="m190.76 189.68 1.1-0.218" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.629"/>
+<path d="m191.86 189.46 1.284-0.392" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.583"/>
+<path d="m193.14 189.07 1.446-0.395" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.551"/>
+<path d="M194.59 188.67l1.319-.464" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.572"/>
+<path d="m195.91 188.21 1.123-0.464" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.609"/>
+<path d="m197.03 187.74 0.908-0.398" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.655"/>
+<path d="M197.94 187.344l.781-.156" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.696"/>
+<path d="m198.72 187.19 0.509-0.078" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.755"/>
+<path d="M199.23 187.11l.253-.077" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.807"/>
+<path d="m199.48 187.03 0.075-0.148" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.828"/>
+<path d="m199.56 186.88 0.12-0.119" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.827"/>
+<path d="m199.68 186.77 0.192-0.243" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.797"/>
+<path d="M199.87 186.523l.427-.374" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.743"/>
+<path d="m200.3 186.15 0.764-0.49" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.672"/>
+<path d="M201.06 185.66l1.178-.444" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.6"/>
+<path d="m202.24 185.22 1.316-0.544" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.566"/>
+<path d="m203.55 184.67 1.254-0.661" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.568"/>
+<path d="m204.81 184.01 1.01-0.761" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.599"/>
+<path d="m205.82 183.25 0.754-0.643" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.655"/>
+<path d="m206.57 182.61 0.382-0.581" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.716"/>
+<path d="m206.95 182.02 0.122-0.459" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.762"/>
+<path d="m207.08 181.57 0.032-0.308" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.797"/>
+<path d="m207.11 181.26 0.179-0.035" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.825"/>
+<path d="m207.29 181.22 0.278-0.024" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.804"/>
+<path d="M207.565 181.2l.385-.189" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.772"/>
+<path d="M207.95 181.011l.468-.499" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.719"/>
+<path d="m208.42 180.51 0.607-0.717" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.665"/>
+<path d="m209.02 179.8 0.607-1.057" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.607"/>
+<path d="m209.63 178.74 0.61-1.297" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.563"/>
+<path d="m210.24 177.44 0.623-1.368" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.549"/>
+<path d="m210.86 176.07 0.705-1.09" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.591"/>
+<path d="M211.57 174.981l.606-.844" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.644"/>
+<path d="m212.18 174.14 0.43-0.586" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.71"/>
+<path d="m212.6 173.55 0.205-0.387" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.77"/>
+<path d="M212.81 173.164l.075-.132" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.831"/>
+<path d="m212.88 173.03-0.09-0.167" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.823"/>
+<path d="m212.8 172.86-0.134-0.339" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.786"/>
+<path d="m212.66 172.53-0.045-0.587" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.738"/>
+<path d="m212.62 171.94 0.217-0.671" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.714"/>
+<path d="m212.83 171.27 0.369-0.886" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.661"/>
+<path d="m213.2 170.38 0.445-1.081" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.617"/>
+<path d="m213.65 169.3 0.414-1.246" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.588"/>
+<path d="m214.06 168.05 0.374-1.2" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.599"/>
+<path d="m214.44 166.85 0.172-1.28" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.592"/>
+<path d="m214.61 165.57-0.026-1.32" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.586"/>
+<path d="m214.58 164.25-0.154-1.27" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.594"/>
+<path d="m214.43 162.98-0.101-0.911" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.67"/>
+<path d="m214.33 162.07-0.077-0.602" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.734"/>
+<path d="M214.25 161.47l-.023-.275" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.804"/>
+<path d="m214.23 161.2 0.027-0.03" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.855"/>
+<path d="M214.254 161.165l.078.079" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.84"/>
+<path d="m214.33 161.24 0.037-0.095" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.842"/>
+<path d="m214.37 161.15v-0.418" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.774"/>
+<path d="M214.37 160.73l-.02-.809" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.692"/>
+<path d="m214.35 159.92-0.011-1.152" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.621"/>
+<path d="m214.34 158.77-0.092-1.485" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.552"/>
+<path d="m214.25 157.28-0.18-1.626" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.522"/>
+<path d="m214.07 155.66-0.237-1.497" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.546"/>
+<path d="m213.83 154.16-0.194-1.041" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.64"/>
+<path d="m213.64 153.12-0.111-0.46" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.763"/>
+<path d="M213.525 152.66l.05.15" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.83"/>
+<path d="M213.574 152.81l.199.51" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.747"/>
+<path d="M213.773 153.32l.235.394" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.766"/>
+<path d="m214.01 153.71 8e-3 -0.385" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.781"/>
+<path d="m214.02 153.33-0.368-1.483" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.544"/>
+<path d="m213.65 151.85-0.723-2.392" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.349"/>
+<path d="m212.92 149.45-0.83-2.558" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.312"/>
+<path d="m212.1 146.9-0.655-1.87" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.452"/>
+<path d="m211.44 145.03-0.198-0.476" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.754"/>
+<path d="M211.242 144.55l.296.923" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.659"/>
+<path d="m211.54 145.47 0.528 1.538" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.524"/>
+<path d="M212.066 147.01l.23.772" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.693"/>
+<path d="m212.3 147.78-0.447-0.995" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.634"/>
+<path d="m211.85 146.79-1.139-2.787" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.249"/>
+<path d="m210.71 144-1.377-3.395" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.124"/>
+<path d="m209.33 140.6-0.975-2.279" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.353"/>
+<path d="m208.36 138.33-0.015 0.32" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.795"/>
+<path d="m208.34 138.65 0.961 3.019" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.219"/>
+<path d="m209.3 141.66 1.273 4.07" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.011"/>
+<path d="m210.58 145.74 0.415 2.182" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.404"/>
+<path d="m210.99 147.92-1.385-2.166" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.336"/>
+<path d="m209.61 145.75-3.288-6.938" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.415"/>
+<path d="m206.32 138.81-4.099-9.178" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.041"/>
+<path d="m202.22 129.64-2.926-6.619" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.488"/>
+<path d="m199.29 123.02 0.483 1.417" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="4.55"/>
+<path d="m199.78 124.43 5.328 13.04" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.476"/>
+<path d="m205.1 137.47 10.068 24.499" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.222"/>
+<path d="m215.17 161.97 12.942 31.495" clip-path="url(#a)" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width=".741"/>
+</g>
+</svg>


### PR DESCRIPTION
Now that GitHub will render an SVG in markdown files, replace the low resolution PNG with a nice vector image. Unfortunate `svgz` is not supported, since that one is only 11KB.

Best we can do for now per request in #297 by @777arc.