### PR TITLE
Fix description of 'core:version' and creation of short-descriptions

### DIFF
--- a/docs-generator.py
+++ b/docs-generator.py
@@ -34,7 +34,7 @@ def gen_table(table, d):
         dtype = value.get("type", "MISSING")
         # default = str(value.get("default", ""))
         longdescription = value.get("description", "")
-        shortdescription = longdescription[: longdescription.find(".")].replace("\n", "")  # short description, which is up to the first period
+        shortdescription = longdescription[: longdescription.find(". ")].replace("\n", "")  # short description, which is up to the first period followed by space
         table.add_row((field, required, dtype, shortdescription))
     table.append(NoEscape("\\bottomrule"))
 

--- a/sigmf-schema.json
+++ b/sigmf-schema.json
@@ -94,7 +94,7 @@
           "maximum": 18446744073709552000
         },
         "core:version": {
-          "description": "The version of the SigMF specification used to create the Metadata file, in the format X.Y.Z",
+          "description": "The version of the SigMF specification used to create the Metadata file, in the format X.Y.Z.",
           "pattern": "^\\d+\\.\\d+\\.\\d",
           "type": "string"
         },


### PR DESCRIPTION
**Problem**
The short description is generated by truncating the long description at the first period (".").
This doesn't work (for example) for the description of `version` in the `global` object, which contains the format specifier "X.Y.Z", the corresponding output is broken (ends with "X").

**Fix**
With the present commit, the first period followed by a space is used to truncate the short description.
Additionally, a missing period at the end of the description of `version` is added.