### PR TITLE
Remove maximum number of channels limitation

### DIFF
--- a/sigmf-schema.json
+++ b/sigmf-schema.json
@@ -83,7 +83,7 @@
           "description": "Number of interleaved channels in the Dataset file, if omitted this is implied to be 1, for multiple channels of IQ data, it is RECOMMENDED to use SigMF Collections instead of num_channels for widest application support.",
           "default": 1,
           "minimum": 1,
-          "maximum": 1000,
+          "maximum": 9223372036854775807,
           "type": "integer"
         },
         "core:offset": {


### PR DESCRIPTION
In df53293baec41ab8a2163fa70a84f357ba700d55, the SigMF spec was converted from Markdown to a JSON schema. Minimum and maximum values were added for many fields. In particular, the core:num_channels field got a maximum value of 1000. The Markdown specification did not specify a maximum value for core:num_channels, so in a sense this is a breaking change between v1.2.1 and v1.2.0 of the spec.

The limitation breaks some usage of SigMF to represent channelizer data, such as the output of the a polyphase-filterbank, or (power-detected) spectrogram data.

This removes the limitation by setting the max value to 2**63 - 1, which is the max value used for other fields.